### PR TITLE
Display current date in assetic:dump --watch

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -53,10 +53,10 @@ class DumpCommand extends ContainerAwareCommand
     {
         $output->writeln(sprintf('Dumping all <comment>%s</comment> assets.', $input->getOption('env')));
         $output->writeln(sprintf('Debug mode is <comment>%s</comment>.', $input->getOption('no-debug') ? 'off' : 'on'));
-        $output->writeln('');
 
         if (!$input->getOption('watch')) {
             foreach ($this->am->getNames() as $name) {
+                $output->writeln('');
                 $this->dumpAsset($name, $output);
             }
 
@@ -97,6 +97,9 @@ class DumpCommand extends ContainerAwareCommand
             try {
                 foreach ($this->am->getNames() as $name) {
                     if ($this->checkAsset($name, $previously)) {
+                        $output->writeln('');
+                        $output->writeln(date('Y-m-d H:i:s'));
+
                         $this->dumpAsset($name, $output);
                     }
                 }


### PR DESCRIPTION
When you use the dump command with watch option is not easy to see if resources were dumped again or not.
I propose to display the current date before the start of each dump.
