### PR TITLE
[AsseticBundle] [Filter] Smartsprites

### DIFF
--- a/AsseticBundle.php
+++ b/AsseticBundle.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\AssetManagerPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\CheckYuiFilterPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\FilterManagerPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\CheckCssEmbedFilterPass;
+use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\CheckSmartSpritesFilterPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\CheckClosureFilterPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\TemplatingPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\SprocketsFilterPass;
@@ -35,6 +36,7 @@ class AsseticBundle extends Bundle
 
         $container->addCompilerPass(new CheckClosureFilterPass());
         $container->addCompilerPass(new CheckCssEmbedFilterPass());
+        $container->addCompilerPass(new CheckSmartSpritesFilterPass());
         $container->addCompilerPass(new CheckYuiFilterPass());
         $container->addCompilerPass(new SprocketsFilterPass());
         $container->addCompilerPass(new TemplatingPass());

--- a/DependencyInjection/Compiler/CheckSmartSpritesFilterPass.php
+++ b/DependencyInjection/Compiler/CheckSmartSpritesFilterPass.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Checks that the location of the SmartSprites JAR has been configured.
+ *
+ * @author Kris Wallsmith <kris@symfony.com>
+ */
+class CheckSmartSpritesFilterPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('assetic.filter.smartsprites') &&
+            !$container->getParameterBag()->resolveValue($container->getParameter('assetic.filter.smartsprites.path'))) {
+            throw new \RuntimeException('The "assetic.filters.smartsprites" configuration requires a "path" value.');
+        }
+    }
+}

--- a/Resources/config/filters/smartsprites.xml
+++ b/Resources/config/filters/smartsprites.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="assetic.filter.smartsprites.class">Assetic\Filter\SmartSpritesFilter</parameter>
+        <parameter key="assetic.filter.smartsprites.path" />
+        <parameter key="assetic.filter.smartsprites.charset">%kernel.charset%</parameter>
+        <parameter key="assetic.filter.smartsprites.loglevel">ERROR</parameter>
+        <parameter key="assetic.filter.smartsprites.document_root">%kernel.root_dir%/../web/</parameter>
+        <parameter key="assetic.filter.smartsprites.sprites_depth">AUTO</parameter>
+        <parameter key="assetic.filter.smartsprites.sprites_ie6">false</parameter>
+        <parameter key="assetic.filter.smartsprites.css_file_suffix"></parameter>
+    </parameters>
+
+    <services>
+        <service id="assetic.filter.smartsprites" class="%assetic.filter.smartsprites.class%">
+            <tag name="assetic.filter" alias="smartsprites" />
+            <argument>%assetic.filter.smartsprites.path%</argument>
+            <call method="setCharset"><argument>%assetic.filter.smartsprites.charset%</argument></call>
+            <call method="setLogLevel"><argument>%assetic.filter.smartsprites.loglevel%</argument></call>
+            <call method="setDocumentRoot"><argument>%assetic.filter.smartsprites.document_root%</argument></call>
+            <call method="setSpritesDepth"><argument>%assetic.filter.smartsprites.sprites_depth%</argument></call>
+            <call method="setSpritesIe6"><argument>%assetic.filter.smartsprites.sprites_ie6%</argument></call>
+            <call method="setCssFileSuffix"><argument>%assetic.filter.smartsprites.css_file_suffix%</argument></call>
+        </service>
+    </services>
+</container>

--- a/Tests/DependencyInjection/AsseticExtensionTest.php
+++ b/Tests/DependencyInjection/AsseticExtensionTest.php
@@ -105,6 +105,7 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
             array('coffee'),
             array('compass'),
             array('cssembed', array('jar' => '/path/to/cssembed.jar')),
+            array('csssprites', array('jar' => '/path/to/csssprites.jar')),
             array('cssimport'),
             array('cssrewrite'),
             array('jpegoptim'),


### PR DESCRIPTION
Added SmartSprites Integration to the Bundle.

Adds following Pull Request for `Assetic` (https://github.com/kriswallsmith/assetic/pull/145)
#1) Installation

---

simply download and extract (http://csssprites.org) to your Application Ressources.
#2) Configuration

---

```
assetic:
    filters:
        smartsprites: 
            path: %kernel.root_dir%/Resources/SMARTSPRITES/DIR
            loglevel: ERROR
            document_root: %kernel.root_dir%/web/
            sprites_depth: AUTO
            sprites_ie6: false
```
#3) Usage

simply use this filter on your `sprites prepared css files`.

```
{% stylesheets  
                'css/content.css'

                filter='smartsprites' output='css/combined.css'
%}
    <link rel="stylesheet" href="{{ asset_url }}">
{% endstylesheets %}
```
#4) Hints

---

The real spriting should always be done from the `CLI` if your Webserver hast not enough permission to write sprited Files.

```
app/console assetic:dump --env=prod
```
