### PR TITLE
making the template resource scanning more flexible

### DIFF
--- a/AsseticBundle.php
+++ b/AsseticBundle.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\AsseticBundle;
 
+use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\TemplateResourcesPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\AssetFactoryPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\AssetManagerPass;
 use Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler\CheckYuiFilterPass;
@@ -33,6 +34,7 @@ class AsseticBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new TemplateResourcesPass());
         $container->addCompilerPass(new CheckClosureFilterPass());
         $container->addCompilerPass(new CheckCssEmbedFilterPass());
         $container->addCompilerPass(new CheckYuiFilterPass());

--- a/DependencyInjection/AsseticExtension.php
+++ b/DependencyInjection/AsseticExtension.php
@@ -121,25 +121,7 @@ class AsseticExtension extends Extension
             $loader->load('asset_writer.xml');
         }
 
-        // bundle and kernel resources
-        foreach ($container->getParameterBag()->resolveValue($config['bundles']) as $bundle) {
-            $rc = new \ReflectionClass($bundles[$bundle]);
-            foreach (array('twig', 'php') as $engine) {
-                $container->setDefinition(
-                    'assetic.'.$engine.'_directory_resource.'.$bundle,
-                    new DirectoryResourceDefinition($bundle, $engine, array(
-                        $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views',
-                        dirname($rc->getFileName()).'/Resources/views',
-                    ))
-                );
-            }
-        }
-        foreach (array('twig', 'php') as $engine) {
-            $container->setDefinition(
-                'assetic.'.$engine.'_directory_resource.kernel',
-                new DirectoryResourceDefinition('', $engine, array($container->getParameter('kernel.root_dir').'/Resources/views'))
-            );
-        }
+        $container->setParameter('assetic.bundles', $config['bundles']);
     }
 
     /**

--- a/DependencyInjection/Compiler/TemplateResourcesPass.php
+++ b/DependencyInjection/Compiler/TemplateResourcesPass.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Bundle\AsseticBundle\DependencyInjection\DirectoryResourceDefinition;
+
+/**
+ * This pass adds directory resources to scan for assetic assets.
+ *
+ * @author Kris Wallsmith <kris@symfony.com>
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class TemplateResourcesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('assetic.asset_manager')) {
+            return;
+        }
+
+        $engines = $container->getParameter('templating.engines');
+
+        // bundle and kernel resources
+        $bundles = $container->getParameter('kernel.bundles');
+        $asseticBundles = $container->getParameterBag()->resolveValue($container->getParameter('assetic.bundles'));
+        foreach ($asseticBundles as $bundleName) {
+            $rc = new \ReflectionClass($bundles[$bundleName]);
+            foreach ($engines as $engine) {
+                $this->setBundleDirectoryResources($container, $engine, dirname($rc->getFileName()), $bundleName);
+            }
+        }
+
+        foreach ($engines as $engine) {
+            $this->setAppDirectoryResources($container, $engine);
+        }
+    }
+
+    protected function setBundleDirectoryResources(ContainerBuilder $container, $engine, $bundleDirName, $bundleName)
+    {
+        $container->setDefinition(
+            'assetic.'.$engine.'_directory_resource.'.$bundleName,
+            new DirectoryResourceDefinition($bundleName, $engine, array(
+                $container->getParameter('kernel.root_dir').'/Resources/'.$bundleName.'/views',
+                $bundleDirName.'/Resources/views',
+            ))
+        );
+    }
+
+    protected function setAppDirectoryResources(ContainerBuilder $container, $engine)
+    {
+        $container->setDefinition(
+            'assetic.'.$engine.'_directory_resource.kernel',
+            new DirectoryResourceDefinition('', $engine, array($container->getParameter('kernel.root_dir').'/Resources/views'))
+        );
+    }
+}

--- a/Resources/config/assetic.xml
+++ b/Resources/config/assetic.xml
@@ -19,6 +19,7 @@
 
         <parameter key="assetic.node.paths" type="collection"></parameter>
         <parameter key="assetic.cache_dir">%kernel.cache_dir%/assetic</parameter>
+        <parameter key="assetic.bundles" type="collection"></parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
see liip/liipthemebundle#7

the key point is that the theme bundle changes the template loading and therefore needs to override the default logic. by moving it to a cache warmer this will be much simpler with minimal code duplication
