### PR TITLE
Fixed vendor dependencies. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.0",
         "symfony/framework-bundle": "2.*",
-        "assetic/assetic": "1.*"
+        "kriswallsmith/assetic": "1.*"
     },
     "suggest": {
         "symfony/twig-bundle": "2.*"


### PR DESCRIPTION
Assetic is known as `kriswallsmith/assetic` in packagist, not `assetic/assetic`.
