### PR TITLE
catch TemplateNameParser exceptions

### DIFF
--- a/Twig/AsseticTokenParser.php
+++ b/Twig/AsseticTokenParser.php
@@ -40,15 +40,16 @@ class AsseticTokenParser extends BaseAsseticTokenParser
     {
         if ($this->templateNameParser && is_array($this->enabledBundles)) {
             // check the bundle
+            $templateRef = null;
             try {
                 $templateRef = $this->templateNameParser->parse($this->parser->getStream()->getFilename());
-                $bundle = $templateRef->get('bundle');
-                if ($bundle && !in_array($bundle, $this->enabledBundles)) {
-                    throw new InvalidBundleException($bundle, "the {% {$this->getTag()} %} tag", $templateRef->getLogicalName(), $this->enabledBundles);
-                }
             } catch(\RuntimeException $e) {
                 // this happens when the filename isn't a Bundle:* url
                 // and it contains ".."
+            }
+            $bundle = $templateRef ? $templateRef->get('bundle') : null;
+            if ($bundle && !in_array($bundle, $this->enabledBundles)) {
+                throw new InvalidBundleException($bundle, "the {% {$this->getTag()} %} tag", $templateRef->getLogicalName(), $this->enabledBundles);
             }
         }
 


### PR DESCRIPTION
AsseticTokenParser attempts to determine the bundle name from the template file name by parsing it with the TemplateNameParser. However, when the file name is already resolved, and is a real file name, containing `..`, this throws an exception (`Template name "%s" contains invalid characters.`).

This PR silently catches this exception, since it's not critical.

I my case the exception was happening when extraction translations with JMSTranslationBundle's translation:extract command.
