### PR TITLE
Gracefully report missing file if not found

### DIFF
--- a/Factory/Resource/FileResource.php
+++ b/Factory/Resource/FileResource.php
@@ -51,7 +51,14 @@ class FileResource implements ResourceInterface
 
     public function getContent()
     {
-        return $this->loader->load($this->getTemplate())->getContent();
+        $templateReference = $this->getTemplate();
+        $fileResource = $this->loader->load($templateReference);
+
+        if (!$fileResource) {
+            throw new \InvalidArgumentException(sprintf('Unable to find template "%s".', $templateReference));
+        }
+
+        return $fileResource->getContent();
     }
 
     public function __toString()


### PR DESCRIPTION
This is a patch that fixes in AsseticBundle the original Symfony PR #3273 (https://github.com/symfony/symfony/pull/3273).
Comments there refer that the fix should be applied here and not in FrameworkBundle as originally proposed.

Ideally this should also backported to 2.0 branch.
