### PR TITLE
Added priority support for services tagged assetic.factory_worker.

### DIFF
--- a/DependencyInjection/Compiler/AssetFactoryPass.php
+++ b/DependencyInjection/Compiler/AssetFactoryPass.php
@@ -29,7 +29,17 @@ class AssetFactoryPass implements CompilerPassInterface
         }
 
         $factory = $container->getDefinition('assetic.asset_factory');
-        foreach ($container->findTaggedServiceIds('assetic.factory_worker') as $id => $attr) {
+        $services = $container->findTaggedServiceIds('assetic.factory_worker');
+
+        // Ascending sort by priority, default is 0
+        uasort($services, function($a, $b) {
+            $p1 = isset($a[0]['priority']) ? $a[0]['priority'] : 0;
+            $p2 = isset($b[0]['priority']) ? $b[0]['priority'] : 0;
+
+            return $p1 - $p2;
+        });
+
+        foreach ($services as $id => $attr) {
             $factory->addMethodCall('addWorker', array(new Reference($id)));
         }
     }

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -32,7 +32,7 @@
             <argument>%assetic.cache_dir%/assets</argument>
         </service>
         <service id="assetic.use_controller_worker" class="%assetic.use_controller_worker.class%" public="false">
-            <tag name="assetic.factory_worker" />
+            <tag name="assetic.factory_worker" priority="-10" />
         </service>
         <service id="assetic.request_listener" class="%assetic.request_listener.class%">
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />


### PR DESCRIPTION
The issue:
- When using `use_controller`, `Asset::getTargetPath()` returns "_controller/…".
- `UseControllerWorker` is used to remove '_controller/' from the path, but when using `apply_to`, it may be registered after the `EnsureFilterWorker` so the filter will not have the updated path.
- When also using `cssrewrite`, it uses `getTargetPath` wrongly adds an extra `../` because of the leading `_controller`.

The fix:
- Added `priority="-10"` to `assetic.use_controller_worker` in `controller.xml`.
- Sorted services tagged `assetic.factory_worker` in `AssetFactoryPass`.

An idea:
- Add priority sorting to [ContainerBuilder::findTaggedServiceIds()](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/ContainerBuilder.php#L838)
