### PR TITLE
[Command] Fix wrong debug mode when calling assetic:dump with --no-debug

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -57,7 +57,7 @@ class DumpCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln(sprintf('Dumping all <comment>%s</comment> assets.', $input->getOption('env')));
-        $output->writeln(sprintf('Debug mode is <comment>%s</comment>.', $input->getOption('no-debug') ? 'off' : 'on'));
+        $output->writeln(sprintf('Debug mode is <comment>%s</comment>.', $this->am->isDebug() ? 'on' : 'off'));
         $output->writeln('');
 
         if (!$input->getOption('watch')) {


### PR DESCRIPTION
As the --no-debug option is a setting used by the console to create the kernel and not a setting for the command, to display the debug mode, the command must not rely on $input->getOption('no-debug') but on $this->am->isDebug().

For example, calling assetic:dump with this these arguments will output in all case "Debug mode is off" although if it's "on" in the config file.

$command = $this->getApplication()->find('assetic:dump');
$arguments = array(
            'command' => 'assetic:dump',
            'write_to' => 'web',
            '--no-debug' => true,
        );
$input = new ArrayInput($arguments);
$returnCode = $command->run($input, $output);
