### PR TITLE
Added support for setting the http_generated_images_path option in the Compass filter

### DIFF
--- a/Resources/config/filters/compass.xml
+++ b/Resources/config/filters/compass.xml
@@ -13,6 +13,7 @@
         <parameter key="assetic.filter.compass.javascripts_dir">null</parameter>
         <parameter key="assetic.filter.compass.http_path">null</parameter>
         <parameter key="assetic.filter.compass.http_images_path">null</parameter>
+        <parameter key="assetic.filter.compass.http_generated_images_path">null</parameter>
         <parameter key="assetic.filter.compass.generated_images_path">null</parameter>
         <parameter key="assetic.filter.compass.http_javascripts_path">null</parameter>
         <parameter key="assetic.filter.compass.plugins" type="collection" />
@@ -31,6 +32,7 @@
             <call method="setJavascriptsDir"><argument>%assetic.filter.compass.javascripts_dir%</argument></call>
             <call method="setHttpPath"><argument>%assetic.filter.compass.http_path%</argument></call>
             <call method="setHttpImagesPath"><argument>%assetic.filter.compass.http_images_path%</argument></call>
+            <call method="setHttpGeneratedImagesPath"><argument>%assetic.filter.compass.http_generated_images_path%</argument></call>
             <call method="setGeneratedImagesPath"><argument>%assetic.filter.compass.generated_images_path%</argument></call>
             <call method="setHttpJavascriptsPath"><argument>%assetic.filter.compass.http_javascripts_path%</argument></call>
             <call method="setPlugins"><argument>%assetic.filter.compass.plugins%</argument></call>


### PR DESCRIPTION
This PR depends on [#301](https://github.com/kriswallsmith/assetic/pull/301) being merged in Assetic.
