### PR TITLE
Add mangle support to uglify js filter

### DIFF
--- a/Resources/config/filters/uglifyjs.xml
+++ b/Resources/config/filters/uglifyjs.xml
@@ -11,6 +11,7 @@
         <parameter key="assetic.filter.uglifyjs.beautify">false</parameter>
         <parameter key="assetic.filter.uglifyjs.no_copyright">false</parameter>
         <parameter key="assetic.filter.uglifyjs.unsafe">false</parameter>
+        <parameter key="assetic.filter.uglifyjs.mangle">false</parameter>
     </parameters>
 
     <services>
@@ -26,6 +27,9 @@
             </call>
             <call method="setUnsafe">
                 <argument>%assetic.filter.uglifyjs.unsafe%</argument>
+            </call>
+            <call method="setMangle">
+                <argument>%assetic.filter.uglifyjs.mangle%</argument>
             </call>
         </service>
     </services>


### PR DESCRIPTION
This pull request allows for applying the `--mangle` paramater to the uglifyjs bin.

It compliments this issue in kriswallsmith/assetic#316
