### PR TITLE
No longer assuming users are homeless

### DIFF
--- a/Resources/config/filters/compass.xml
+++ b/Resources/config/filters/compass.xml
@@ -18,7 +18,7 @@
         <parameter key="assetic.filter.compass.http_javascripts_path">null</parameter>
         <parameter key="assetic.filter.compass.plugins" type="collection" />
         <parameter key="assetic.filter.compass.load_paths" type="collection" />
-        <parameter key="assetic.filter.compass.home_env">true</parameter>
+        <parameter key="assetic.filter.compass.home_env">false</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
With this configuration enabled, users are assumed to be homeless. That forces Assetic to use /tmp as $HOME, which in turn bypasses your entire Ruby setup. Including the very popular Ruby Version Manager (RVM).

My commit changes the configuration to what I feel is a much more sensible default.
