### PR TITLE
Allow setting import paths for scssphp from the config

### DIFF
--- a/Resources/config/filters/scssphp.xml
+++ b/Resources/config/filters/scssphp.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="assetic.filter.scssphp.class">Assetic\Filter\ScssphpFilter</parameter>
         <parameter key="assetic.filter.scssphp.import_paths" type="collection" />
+        <parameter key="assetic.filter.scssphp.compass">false</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
Related to https://github.com/kriswallsmith/assetic/pull/318

One question though, this PR makes it required for the "import_paths" config parameter to be set. How do I make it optional? This, by the way, also goes for the relatively new compass option
