### PR TITLE
Resolve values before looking at them

### DIFF
--- a/DependencyInjection/Compiler/RouterResourcePass.php
+++ b/DependencyInjection/Compiler/RouterResourcePass.php
@@ -24,10 +24,13 @@ class RouterResourcePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->getParameter('assetic.use_controller') || !$container->getParameter('router.resource')) {
+        $useController = $container->getParameterBag()->resolveValue($container->getParameter('assetic.use_controller'));
+        $routerResource = $container->getParameterBag()->resolveValue($container->getParameter('router.resource'));
+
+        if (!$useController || !$routerResource) {
             return;
         }
-
+        
         $file = $container->getParameter('kernel.cache_dir').'/assetic/routing.yml';
 
         if (!is_dir($dir = dirname($file))) {


### PR DESCRIPTION
At least for use_controller the default value defined in Symfony\Bundle\AsseticBundle\DependencyInjection\Configuration is "%kernel.debug%", which you will get literally as a string if you don't call resolveValue().
