### PR TITLE
Make use of CompassFilter::setNoLineComments to turn off comments in compiled css

### DIFF
--- a/Resources/config/filters/compass.xml
+++ b/Resources/config/filters/compass.xml
@@ -8,6 +8,7 @@
         <parameter key="assetic.filter.compass.class">Assetic\Filter\CompassFilter</parameter>
         <parameter key="assetic.filter.compass.bin">/usr/bin/compass</parameter>
         <parameter key="assetic.filter.compass.debug">false</parameter>
+		<parameter key="assetic.filter.compass.no_line_comments">false</parameter>
         <parameter key="assetic.filter.compass.style">null</parameter>
         <parameter key="assetic.filter.compass.images_dir">null</parameter>
         <parameter key="assetic.filter.compass.fonts_dir">null</parameter>
@@ -29,6 +30,7 @@
             <argument>%assetic.filter.compass.bin%</argument>
             <argument>%assetic.ruby.bin%</argument>
             <call method="setDebugInfo"><argument>%assetic.filter.compass.debug%</argument></call>
+            <call method="setNoLineComments"><argument>%assetic.filter.compass.no_line_comments%</argument></call>
             <call method="setStyle"><argument>%assetic.filter.compass.style%</argument></call>
             <call method="setImagesDir"><argument>%assetic.filter.compass.images_dir%</argument></call>
             <call method="setFontsDir"><argument>%assetic.filter.compass.fonts_dir%</argument></call>


### PR DESCRIPTION
I'm not sure if there is a way to do this that I'm missing but i spun my wheels for a good bit trying different settings in config.yml and parameters.yml to turn off the debug comment output for CompassFilter. I finally took a look at the bundle and realized the parameter wasn't set up.

If this is already supported in some other way please let me know.
