### PR TITLE
Adding new option for setting Java stack size in yui_css compressor

### DIFF
--- a/Resources/config/filters/yui_css.xml
+++ b/Resources/config/filters/yui_css.xml
@@ -9,7 +9,7 @@
         <parameter key="assetic.filter.yui_css.java">%assetic.java.bin%</parameter>
         <parameter key="assetic.filter.yui_css.jar" />
         <parameter key="assetic.filter.yui_css.charset">%kernel.charset%</parameter>
-		<parameter key="assetic.filter.yui_css.stacksize">512k</parameter>
+        <parameter key="assetic.filter.yui_css.stacksize">512k</parameter>
         <parameter key="assetic.filter.yui_css.timeout">null</parameter>
     </parameters>
 
@@ -20,7 +20,7 @@
             <argument>%assetic.filter.yui_css.java%</argument>
             <call method="setCharset"><argument>%assetic.filter.yui_css.charset%</argument></call>
             <call method="setTimeout"><argument>%assetic.filter.yui_css.timeout%</argument></call>
-			<call method="setStackSize"><argument>%assetic.filter.yui_css.stacksize%</argument></call>
+            <call method="setStackSize"><argument>%assetic.filter.yui_css.stacksize%</argument></call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
As yuicompressor sometimes have stack size problems while compressing
complicated CSS files, here I set a new stacksize option.

This commit can only be merged after assetic merges the corresponding pull request.
