### PR TITLE
Respect the combine flag when dumping leafs

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -189,8 +189,8 @@ class DumpCommand extends ContainerAwareCommand
         $debug = isset($formula[2]['debug']) ? $formula[2]['debug'] : $this->am->isDebug();
         $combine = isset($formula[2]['combine']) ? $formula[2]['combine'] : !$debug;
 
-        // dump each leaf if debug but no combine
-        if ($debug && !$combine) {
+        // dump each leaf if no combine
+        if (!$combine) {
             foreach ($asset as $leaf) {
                 $this->doDump($leaf, $output);
             }


### PR DESCRIPTION
Dumping assets in the dev environment (with the --watch switch) can take a long time. Especially if we use many files and some kind of a compiler (eg. Coffeescript). One solution is using the combine=true switch at the asset declaration. But the bundle ignores this setting, and still generates all leaf assets, even if they are never used. It is probably ok for debug purposes, but still takes a long time, and if you use some auto-update solution like https://github.com/mbence/LivePHPBundle it can be outright annoying (refreshing the browser multiple times while all the assets are generated).

I added a small change to the dumpAsset function, to watch for the combine setting, and if on, skip the leaf files. If you need to debug, you switch off combine, but if you want speedy development, then don't dump the unnecessary files.

I hope this would be useful for others too.
Thanks: Bence
