### PR TITLE
[fix] Bug introduced in 9167375c38ee

### DIFF
--- a/Resources/config/filters/less.xml
+++ b/Resources/config/filters/less.xml
@@ -17,7 +17,6 @@
             <tag name="assetic.filter" alias="less" />
             <argument>%assetic.filter.less.node%</argument>
             <argument>%assetic.filter.less.node_paths%</argument>
-            <call method="setTimeout"><argument>%assetic.filter.less.timeout%</argument></call>
             <call method="setCompress"><argument>%assetic.filter.less.compress%</argument></call>
         </service>
     </services>


### PR DESCRIPTION
While `Assetic\Filter\LessFilter::setTimeout` method is not yet implemented, it seems smart to get rid of the call in service config for the time.
