### PR TITLE
Add option to dump only leafs in --watch

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -168,7 +168,7 @@ class DumpCommand extends ContainerAwareCommand
     private function checkAsset($name, array &$previously)
     {
         // Leaf assets don't have names. Passing asset itself.
-        if ($name instanceof \Assetic\Asset\BaseAsset) {
+        if ($name instanceof \Assetic\Asset\AssetInterface) {
             $asset = $name;
             // Set name to source path.
             // Since it's used purely for key in $previous,


### PR DESCRIPTION
While working with many files that are combined under single asset I noticed how slow it is when script has to dump 10+ leafs when only one changes. The new option allows to dump only leafs. And, since I'm using assetic in debug mode without controllers, that's exactly what I need. I think this should benefit everyone who's developing javascript heavy applications with more than 5 files combined. Especially when using compilers (coffeescript, less etc).
