### PR TITLE
LessPHP Filter: Add setLoadPaths call

### DIFF
--- a/Resources/config/filters/lessphp.xml
+++ b/Resources/config/filters/lessphp.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="assetic.filter.lessphp.class">Assetic\Filter\LessphpFilter</parameter>
         <parameter key="assetic.filter.lessphp.presets" type="collection"></parameter>
+        <parameter key="assetic.filter.lessphp.paths" type="collection"></parameter>
         <!--
         "formatter" can be set to one of: "lessjs", "compressed", "classic".
         See http://leafo.net/lessphp/docs/#output_formatting


### PR DESCRIPTION
Sets the lessphp load paths from the existing "paths" configuration node. Goes hand in hand with https://github.com/kriswallsmith/assetic/pull/388
