### PR TITLE
Skip assets created by the assetic.asset DI tag in the routing

### DIFF
--- a/Routing/AsseticLoader.php
+++ b/Routing/AsseticLoader.php
@@ -61,6 +61,10 @@ class AsseticLoader extends Loader
 
         // routes
         foreach ($this->am->getNames() as $name) {
+            if (!$this->am->hasFormula($name)) {
+                continue;
+            }
+
             $asset = $this->am->get($name);
             $formula = $this->am->getFormula($name);
 


### PR DESCRIPTION
I'm adding assetic tags to the [Symfony reference](http://symfony.com/doc/master/reference/dic_tags.html). For the `assetic.asset` tag, the only  use case I can think of is:

``` yaml
services:
    my_asset:
        class: Assetic\Asset\StringAsset
        arguments: [ 'alert("Hey dawg!");' ]
        tags:
            - { name: assetic.asset, alias: my_asset }
```

``` twig
{% javascripts '@my_asset' %}
    <script src="{{ asset_url }}"></script>
{% endjavascripts %}
```

But this code produces an error in `Symfony\Bundle\AsseticBundle\Routing::load()`. It happens because this method tries to get a formula for every asset, while our asset doesn't have a formula. This PR skips assets without formulae.
