### PR TITLE
Add ember-precompile support

### DIFF
--- a/Resources/config/filters/emberprecompile.xml
+++ b/Resources/config/filters/emberprecompile.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="assetic.filter.emberprecompile.class">Assetic\Filter\EmberPrecompileFilter</parameter>
+        <parameter key="assetic.filter.emberprecompile.bin">/usr/bin/ember-precompile</parameter>
+        <parameter key="assetic.filter.emberprecompile.node">%assetic.node.bin%</parameter>
+        <parameter key="assetic.filter.emberprecompile.node_paths">%assetic.node.paths%</parameter>
+        <parameter key="assetic.filter.emberprecompile.timeout">null</parameter>
+    </parameters>
+
+    <services>
+        <service id="assetic.filter.emberprecompile" class="%assetic.filter.emberprecompile.class%">
+            <tag name="assetic.filter" alias="emberprecompile" />
+            <argument>%assetic.filter.emberprecompile.bin%</argument>
+            <argument>%assetic.filter.emberprecompile.node%</argument>
+            <call method="setTimeout"><argument>%assetic.filter.emberprecompile.timeout%</argument></call>
+            <call method="setNodePaths"><argument>%assetic.filter.emberprecompile.node_paths%</argument></call>
+        </service>
+    </services>
+</container>

--- a/Tests/DependencyInjection/AsseticExtensionTest.php
+++ b/Tests/DependencyInjection/AsseticExtensionTest.php
@@ -113,6 +113,7 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
             array('cssmin'),
             array('cssrewrite'),
             array('dart'),
+            array('emberprecompile'),
             array('gss'),
             array('handlebars'),
             array('jpegoptim'),


### PR DESCRIPTION
Adds a configuration file to use the ember-precompile filter with the bundle.
