### PR TITLE
Allows setting load paths for less, sass and scss filters through configuration.

### DIFF
--- a/Resources/config/filters/less.xml
+++ b/Resources/config/filters/less.xml
@@ -10,6 +10,7 @@
         <parameter key="assetic.filter.less.node_paths">%assetic.node.paths%</parameter>
         <parameter key="assetic.filter.less.timeout">null</parameter>
         <parameter key="assetic.filter.less.compress">null</parameter>
+        <parameter key="assetic.filter.less.load_paths" type="collection" />
     </parameters>
 
     <services>
@@ -19,6 +20,7 @@
             <argument>%assetic.filter.less.node_paths%</argument>
             <call method="setTimeout"><argument>%assetic.filter.less.timeout%</argument></call>
             <call method="setCompress"><argument>%assetic.filter.less.compress%</argument></call>
+            <call method="setLoadPaths"><argument>%assetic.filter.less.load_paths%</argument></call>
         </service>
     </services>
 </container>

--- a/Resources/config/filters/sass.xml
+++ b/Resources/config/filters/sass.xml
@@ -10,6 +10,7 @@
         <parameter key="assetic.filter.sass.timeout">null</parameter>
         <parameter key="assetic.filter.sass.style">null</parameter>
         <parameter key="assetic.filter.sass.compass">null</parameter>
+        <parameter key="assetic.filter.sass.load_paths" type="collection" />
     </parameters>
 
     <services>
@@ -20,6 +21,7 @@
             <call method="setTimeout"><argument>%assetic.filter.sass.timeout%</argument></call>
             <call method="setStyle"><argument>%assetic.filter.sass.style%</argument></call>
             <call method="setCompass"><argument>%assetic.filter.sass.compass%</argument></call>
+            <call method="setLoadPaths"><argument>%assetic.filter.sass.load_paths%</argument></call>
         </service>
     </services>
 </container>

--- a/Resources/config/filters/scss.xml
+++ b/Resources/config/filters/scss.xml
@@ -10,6 +10,7 @@
         <parameter key="assetic.filter.scss.timeout">null</parameter>
         <parameter key="assetic.filter.scss.style">null</parameter>
         <parameter key="assetic.filter.scss.compass">null</parameter>
+        <parameter key="assetic.filter.scss.load_paths" type="collection" />
     </parameters>
 
     <services>
@@ -20,6 +21,7 @@
             <call method="setTimeout"><argument>%assetic.filter.scss.timeout%</argument></call>
             <call method="setStyle"><argument>%assetic.filter.scss.style%</argument></call>
             <call method="setCompass"><argument>%assetic.filter.scss.compass%</argument></call>
+            <call method="setLoadPaths"><argument>%assetic.filter.scss.load_paths%</argument></call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Allows setting load paths through config for less, sass and scss filters. For example, when adding bootstrap through composer you might want to add the directory under vendor into the filters load path.

Example adding sass-twitter-bootstrap

``` yml
# config.yml
assetic:
    filters:
        cssrewrite: ~
        scss:
            sass: #Path to sass bin
            apply_to: "\.scss$"

            # Adds jlong's sass version of bootstrap to the load path
            load_paths:
                - "%kernel.root_dir%/../vendor/jlong/sass-twitter-bootstrap/lib/"
```

This fix requires the pull request for Assetic to be merged.
https://github.com/kriswallsmith/assetic/pull/404
