### PR TITLE
Added support for YUI's --line-break setting

### DIFF
--- a/Resources/config/filters/yui_css.xml
+++ b/Resources/config/filters/yui_css.xml
@@ -11,6 +11,7 @@
         <parameter key="assetic.filter.yui_css.charset">%kernel.charset%</parameter>
         <parameter key="assetic.filter.yui_css.stacksize">null</parameter>
         <parameter key="assetic.filter.yui_css.timeout">null</parameter>
+        <parameter key="assetic.filter.yui_css.linebreak">null</parameter>
     </parameters>
 
     <services>
@@ -21,6 +22,7 @@
             <call method="setCharset"><argument>%assetic.filter.yui_css.charset%</argument></call>
             <call method="setTimeout"><argument>%assetic.filter.yui_css.timeout%</argument></call>
             <call method="setStackSize"><argument>%assetic.filter.yui_css.stacksize%</argument></call>
+            <call method="setLineBreak"><argument>%assetic.filter.yui_css.linebreak%</argument></call>
         </service>
     </services>
 </container>

--- a/Resources/config/filters/yui_js.xml
+++ b/Resources/config/filters/yui_js.xml
@@ -14,6 +14,7 @@
         <parameter key="assetic.filter.yui_js.nomunge">null</parameter>
         <parameter key="assetic.filter.yui_js.preserve_semi">null</parameter>
         <parameter key="assetic.filter.yui_js.disable_optimizations">null</parameter>
+        <parameter key="assetic.filter.yui_js.linebreak">null</parameter>
     </parameters>
 
     <services>
@@ -27,6 +28,7 @@
             <call method="setNomunge"><argument>%assetic.filter.yui_js.nomunge%</argument></call>
             <call method="setPreserveSemi"><argument>%assetic.filter.yui_js.preserve_semi%</argument></call>
             <call method="setDisableOptimizations"><argument>%assetic.filter.yui_js.disable_optimizations%</argument></call>
+            <call method="setLineBreak"><argument>%assetic.filter.yui_js.linebreak%</argument></call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
YUI (and Assetic) supports setting max length of lines in CSS & JS files. This PR adds support to configure the maximum line length by adding `linebreak:` in bundle configuration.

``` yaml
assetic:
    filters:
        yui_js:
            linebreak: 1000
        yui_css:
            linebreak: 1000
```
