### PR TITLE
Fix signature of the UseControllerWork to respect WorkerInterface

### DIFF
--- a/Factory/Worker/UseControllerWorker.php
+++ b/Factory/Worker/UseControllerWorker.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\AsseticBundle\Factory\Worker;
 
 use Assetic\Asset\AssetInterface;
 use Assetic\Factory\Worker\WorkerInterface;
+use Assetic\Factory\AssetFactory;
 
 /**
  * Prepends a fake front controller so the asset knows where it is-ish.
@@ -21,7 +22,7 @@ use Assetic\Factory\Worker\WorkerInterface;
  */
 class UseControllerWorker implements WorkerInterface
 {
-    public function process(AssetInterface $asset)
+    public function process(AssetInterface $asset, AssetFactory $factory)
     {
         $targetUrl = $asset->getTargetPath();
         if ($targetUrl && '/' != $targetUrl[0] && 0 !== strpos($targetUrl, '_controller/')) {


### PR DESCRIPTION
Bug related to https://github.com/kriswallsmith/assetic/commit/01d4d8355b7541475985bf1c1fd54edd6eac57aa

PHP Fatal error:  Declaration of Symfony\Bundle\AsseticBundle\Factory\Worker\UseControllerWorker::process() must be compatible with Assetic\Factory\Worker\WorkerInterface::process(Assetic\Asset\AssetInterface $asset, Assetic\Factory\AssetFactory $factory)
