### PR TITLE
Closure language can be configured

### DIFF
--- a/Resources/config/filters/closure.xml
+++ b/Resources/config/filters/closure.xml
@@ -10,6 +10,7 @@
         <parameter key="assetic.filter.closure.java">%assetic.java.bin%</parameter>
         <parameter key="assetic.filter.closure.timeout">null</parameter>
         <parameter key="assetic.filter.closure.compilation_level">null</parameter>
+        <parameter key="assetic.filter.closure.language">null</parameter>
     </parameters>
 
     <services>
@@ -19,6 +20,7 @@
             <argument>%assetic.filter.closure.java%</argument>
             <call method="setTimeout"><argument>%assetic.filter.closure.timeout%</argument></call>
             <call method="setCompilationLevel"><argument>%assetic.filter.closure.compilation_level%</argument></call>
+            <call method="setLanguage"><argument>%assetic.filter.closure.language%</argument></call>
         </service>
 
         <service id="assetic.filter.closure.api" class="%assetic.filter.closure.api.class%">


### PR DESCRIPTION
I came across similar difficulties with closure compiler as described here: https://github.com/symfony/AsseticBundle/issues/165

The commit introduces new assetic.filter.closure.language config option that configures the Assetic\Filter\GoogleClosure\BaseCompilerFilter class to use other than default "--language_in" compiler argument value.
