### PR TITLE
[2.1][FIX] Class not found in dump command

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\AsseticBundle\Command;
 
-use Assetic\Util\PathUtils;
+use Assetic\Util\VarUtils;
 
 use Assetic\AssetWriter;
 use Assetic\Asset\AssetInterface;
@@ -213,7 +213,7 @@ class DumpCommand extends ContainerAwareCommand
             $asset->setValues($combination);
 
             $target = rtrim($this->basePath, '/').'/'.str_replace('_controller/', '',
-                PathUtils::resolvePath($asset->getTargetPath(), $asset->getVars(),
+                VarUtils::resolve($asset->getTargetPath(), $asset->getVars(),
                     $asset->getValues()));
             if (!is_dir($dir = dirname($target))) {
                 $output->writeln(sprintf(


### PR DESCRIPTION
Fix rename PathUtils Assetic para VarUtils view: 
https://github.com/kriswallsmith/assetic/tree/bfe832e2a026301121cb5a13f36954708186cf32/src/Assetic/Util

I believe that should have a new release 2.1.4 or 2.2.  

Greetings,
Ramon
