### PR TITLE
[2.1][FIX] Class not found in dump command

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -11,8 +11,7 @@
 
 namespace Symfony\Bundle\AsseticBundle\Command;
 
-use Assetic\Util\PathUtils;
-
+use Assetic\Util\VarUtils;
 use Assetic\AssetWriter;
 use Assetic\Asset\AssetInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -213,7 +212,7 @@ class DumpCommand extends ContainerAwareCommand
             $asset->setValues($combination);
 
             $target = rtrim($this->basePath, '/').'/'.str_replace('_controller/', '',
-                PathUtils::resolvePath($asset->getTargetPath(), $asset->getVars(),
+                VarUtils::resolve($asset->getTargetPath(), $asset->getVars(),
                     $asset->getValues()));
             if (!is_dir($dir = dirname($target))) {
                 $output->writeln(sprintf(

--- a/Tests/Resources/config/config.yml
+++ b/Tests/Resources/config/config.yml
@@ -6,7 +6,7 @@ framework:
     validation:    { enabled: true, enable_annotations: true }
     templating:    { engines: ['twig', 'php'] }
     session:
-        lifetime:   3600
+        cookie-lifetime: 3600
 
 twig:
     debug:            %kernel.debug%


### PR DESCRIPTION
Fixes a bug in dump command using a non-existent class.
