### PR TITLE
Added assetic:list command to output list of asset files and their md5 hash

### DIFF
--- a/Command/ListCommand.php
+++ b/Command/ListCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Command;
+
+use Assetic\Asset\AssetInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Outputs a list of all asset files and optionally an md5 hash of each asset,
+ * from the source file content (--md5=file) or the dumped output (--md5=dump)
+ *
+ * Output can be used to calculate a hash of all source files for cache busting.
+ *
+ * @author Ville Mattila <ville@eventio.fi>
+ */
+class ListCommand extends ContainerAwareCommand
+{
+    private $am;
+    
+    private $paths;
+    private $md5;
+
+    protected function configure()
+    {
+        $this
+            ->setName('assetic:list')
+            ->setDescription('Outputs a list of all asset files.')
+            ->addOption('paths', null, InputOption::VALUE_NONE, 'Output full file paths.')
+            ->addOption('md5', null, InputOption::VALUE_REQUIRED, 'Prepends each file with an MD5 hash of the file content. Supported values: dump, file')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->paths = $input->getOption('paths');
+        $this->md5 = $input->getOption('md5');
+
+        if ($this->md5 && false === in_array($this->md5, array('dump','file'))) {
+            throw new \InvalidArgumentException('Option --md5 contains invalid value "' . $this->md5 . '". Accepted values: dump, file.');
+        }
+
+        $this->am = $this->getContainer()->get('assetic.asset_manager');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        foreach ($this->am->getNames() as $name) {
+            $asset = $this->am->get($name);
+            $this->printAsset($asset, $output);
+        }
+    }
+
+    /**
+     * Does the actual print for the asset and it's leafs
+     *
+     * @param AssetInterface  $asset  The asset, as given in execute() function
+     * @param OutputInterface $output The command output
+     */
+    private function printAsset(AssetInterface $asset, OutputInterface $output)
+    {
+        
+        $this->doPrint($asset, $output);
+        foreach ($asset as $leaf) {
+            $this->doPrint($leaf, $output);
+        }
+    }
+
+    /**
+     * Prints out the actual asset information: md5 sum (optionally) and (full) path
+     *
+     * @param AssetInterface  $asset  The asset
+     * @param OutputInterface $output The command output
+     */
+    private function doPrint(AssetInterface $asset, OutputInterface $output)
+    {
+        $source = $asset->getSourcePath();
+        if ($source) {
+            if ($this->paths) {
+                $path = $asset->getSourceRoot() . '/' . $source;
+            } else {
+                $path = $source;
+            }
+
+            if ($this->md5) {
+                if ($this->md5 === 'dump') {
+                    $md5 = md5($asset->dump());
+                } elseif ($this->md5 === 'file') {
+                    $md5 = md5_file($asset->getSourceRoot() . '/' . $source);
+                }
+                $output->writeln($md5 . ' ' . $path);
+            } else {
+                $output->writeln($path);
+            }
+        }
+    }
+}

--- a/Tests/Command/ListCommandTest.php
+++ b/Tests/Command/ListCommandTest.php
@@ -145,6 +145,37 @@ class ListCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("test_asset.css" . PHP_EOL . "test_asset.js" . PHP_EOL, $output);
     }
     
+    public function testListMultipleAssetsWithPrint0()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetCollection');
+        $leaf1 = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $leaf2 = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $this->am->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(array('test_asset')));
+        $this->am->expects($this->once())
+            ->method('get')
+            ->with('test_asset')
+            ->will($this->returnValue($asset));
+        $asset->expects($this->once())
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator(array($leaf1, $leaf2))));
+        $asset->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue(null));
+        $leaf1->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.css'));
+        $leaf2->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.js'));
+
+        $output = $this->runCommandGetOutput(array('--print0' => true));
+
+        $this->assertEquals("test_asset.css" . chr(0) . "test_asset.js" . chr(0), $output);
+    }
+    
     public function testListMultiLevelAssets()
     {
         $asset = $this->getMock('Assetic\\Asset\\AssetCollection');

--- a/Tests/Command/ListCommandTest.php
+++ b/Tests/Command/ListCommandTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Tests\Command;
+
+use Symfony\Bundle\AsseticBundle\Command\ListCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ListCommandTest extends \PHPUnit_Framework_TestCase
+{
+    private $application;
+    private $definition;
+    private $kernel;
+    private $container;
+    private $am;
+
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\Console\Application')) {
+            $this->markTestSkipped('Symfony Console is not available.');
+        }
+
+        $this->application = $this->getMockBuilder('Symfony\\Bundle\\FrameworkBundle\\Console\\Application')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->definition = $this->getMockBuilder('Symfony\\Component\\Console\\Input\\InputDefinition')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->kernel = $this->getMock('Symfony\\Component\\HttpKernel\\KernelInterface');
+        $this->helperSet = $this->getMock('Symfony\\Component\\Console\\Helper\\HelperSet');
+        $this->container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $this->am = $this->getMockBuilder('Assetic\\Factory\\LazyAssetManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->application->expects($this->any())
+            ->method('getDefinition')
+            ->will($this->returnValue($this->definition));
+        $this->definition->expects($this->any())
+            ->method('getArguments')
+            ->will($this->returnValue(array()));
+        $this->definition->expects($this->any())
+            ->method('getOptions')
+            ->will($this->returnValue(array(
+                new InputOption('--verbose', '-v', InputOption::VALUE_NONE, 'Increase verbosity of messages.'),
+                new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', 'dev'),
+                new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'),
+            )));
+        $this->application->expects($this->any())
+            ->method('getKernel')
+            ->will($this->returnValue($this->kernel));
+        $this->application->expects($this->once())
+            ->method('getHelperSet')
+            ->will($this->returnValue($this->helperSet));
+        $this->kernel->expects($this->any())
+            ->method('getContainer')
+            ->will($this->returnValue($this->container));
+
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with('assetic.asset_manager')
+            ->will($this->returnValue($this->am));
+
+        $this->command = new ListCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    public function testEmptyAssetManager()
+    {
+        $this->am->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(array()));
+
+        $this->runCommandGetOutput();
+    }
+    
+    private function runCommandGetOutput($inputArray = array()) {
+        
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute($inputArray);
+        
+        return $commandTester->getDisplay();
+    }
+
+    public function testListOne()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $this->am->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(array('test_asset')));
+        $this->am->expects($this->once())
+            ->method('get')
+            ->with('test_asset')
+            ->will($this->returnValue($asset));
+        $asset->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.css'));
+
+        $output = $this->runCommandGetOutput();
+
+        $this->assertEquals("test_asset.css" . PHP_EOL, $output);
+    }
+
+    public function testListMultipleAssets()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetCollection');
+        $leaf1 = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $leaf2 = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $this->am->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(array('test_asset')));
+        $this->am->expects($this->once())
+            ->method('get')
+            ->with('test_asset')
+            ->will($this->returnValue($asset));
+        $asset->expects($this->once())
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator(array($leaf1, $leaf2))));
+        $asset->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue(null));
+        $leaf1->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.css'));
+        $leaf2->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.js'));
+
+        $output = $this->runCommandGetOutput();
+
+        $this->assertEquals("test_asset.css" . PHP_EOL . "test_asset.js" . PHP_EOL, $output);
+    }
+    
+    public function testListMultiLevelAssets()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetCollection');
+        $leaf1 = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $leaf2 = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $firstLevelAsset = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $this->am->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(array(
+                'test_asset','first_level_asset'
+            )));
+            
+        $this->am->expects($this->any())
+            ->method('get')
+            ->will($this->returnValueMap(array(
+                array('test_asset', $asset),
+                array('first_level_asset', $firstLevelAsset)
+            )));
+            
+        $asset->expects($this->once())
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator(array($leaf1, $leaf2))));
+        $asset->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue(null));
+            
+        $leaf1->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.css'));
+        $leaf2->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.js'));
+            
+        $firstLevelAsset->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('first_level_asset.js'));
+
+        $output = $this->runCommandGetOutput();
+
+        $this->assertEquals("test_asset.css" . PHP_EOL . "test_asset.js" . PHP_EOL . "first_level_asset.js" . PHP_EOL, $output);
+    }
+    
+    public function testListFullPathsAssets()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetCollection');
+        $leaf1 = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $leaf2 = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $firstLevelAsset = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $this->am->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(array(
+                'test_asset','first_level_asset'
+            )));
+            
+        $this->am->expects($this->any())
+            ->method('get')
+            ->will($this->returnValueMap(array(
+                array('test_asset', $asset),
+                array('first_level_asset', $firstLevelAsset)
+            )));
+            
+        $asset->expects($this->once())
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator(array($leaf1, $leaf2))));
+        $asset->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue(null));
+            
+        $leaf1->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.css'));
+        $leaf1->expects($this->once())
+            ->method('getSourceRoot')
+            ->will($this->returnValue('/path_to'));
+            
+        $leaf2->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.js'));
+        $leaf2->expects($this->once())
+            ->method('getSourceRoot')
+            ->will($this->returnValue('/another_path'));
+            
+        $firstLevelAsset->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('first_level_asset.js'));
+        $firstLevelAsset->expects($this->once())
+            ->method('getSourceRoot')
+            ->will($this->returnValue('/path_to'));
+
+        $output = $this->runCommandGetOutput(array('--paths' => true));
+
+        $this->assertEquals(
+            "/path_to/test_asset.css" . PHP_EOL .
+            "/another_path/test_asset.js" . PHP_EOL .
+            "/path_to/first_level_asset.js" . PHP_EOL,
+        $output);
+    }
+
+    public function testMD5Output()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetCollection');
+        $leaf1 = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $leaf2 = $this->getMock('Assetic\\Asset\\AssetInterface');
+        $firstLevelAsset = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $this->am->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(array(
+                'test_asset','first_level_asset'
+            )));
+            
+        $this->am->expects($this->any())
+            ->method('get')
+            ->will($this->returnValueMap(array(
+                array('test_asset', $asset),
+                array('first_level_asset', $firstLevelAsset)
+            )));
+            
+        $asset->expects($this->once())
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator(array($leaf1, $leaf2))));
+        $asset->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue(null));
+        $asset->expects($this->never())
+            ->method('dump');
+            
+        $leaf1->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.css'));
+        $leaf1->expects($this->once())
+            ->method('getSourceRoot')
+            ->will($this->returnValue('/path_to'));
+        $leaf1->expects($this->once())
+            ->method('dump')
+            ->will($this->returnValue("test_content\n")); //87978e0dfadc2f75cafc0d21600eaa55
+
+        $leaf2->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('test_asset.js'));
+        $leaf2->expects($this->once())
+            ->method('getSourceRoot')
+            ->will($this->returnValue('/another_path'));
+        $leaf2->expects($this->once())
+            ->method('dump')
+            ->will($this->returnValue("other content\n")); //33fe21c6bdf6786411e4f18272956536
+            
+        $firstLevelAsset->expects($this->once())
+            ->method('getSourcePath')
+            ->will($this->returnValue('first_level_asset.js'));
+        $firstLevelAsset->expects($this->once())
+            ->method('getSourceRoot')
+            ->will($this->returnValue('/path_to'));
+        $firstLevelAsset->expects($this->once())
+            ->method('dump')
+            ->will($this->returnValue("third\n")); //aa62cba149c51923916eff46f80fe74c
+
+        $output = $this->runCommandGetOutput(array('--paths' => true, '--md5' => 'dump'));
+
+        $this->assertEquals(
+            "87978e0dfadc2f75cafc0d21600eaa55 /path_to/test_asset.css" . PHP_EOL .
+            "33fe21c6bdf6786411e4f18272956536 /another_path/test_asset.js" . PHP_EOL .
+            "aa62cba149c51923916eff46f80fe74c /path_to/first_level_asset.js" . PHP_EOL,
+        $output);
+    }
+}


### PR DESCRIPTION
This PR introduces a new command, `assetic:list` that produces a list of all asset files and optionally an md5 hash from dumped output or source file contents:

```
$ app/console assetic:list --md5=file
429ec0da456d16a44ec609153322fa94 css/reset.css
71622ad6e734e307fb22437261e4b39a css/480.css
```

To output full file paths, use `--paths`:

```
429ec0da456d16a44ec609153322fa94 /var/www/symfony2-project/app/../web/css/reset.css
71622ad6e734e307fb22437261e4b39a /var/www/symfony2-project/app/../web/css/480.css
```

**Use Case: Cache Busting**

As there is not yet reliable cache busting solution (see for example https://github.com/symfony/AsseticBundle/pull/119 ), we do use the output of `assetic:list` to generate a master hash of all asset files:
`$ app/console --env=prod assetic:list --md5=file | md5sum`

If the master hash changes between deployments (meaning a source file content has changed, a new file is added, a file is renamed or removed), we'll do actual `assetic:dump` and upload new dumped files to CDN to an address prefixed with the master hash. The master hash is set to `framework.templating.assets_base_urls` configuration variable in `config.yml`.

`--md5=file` does not directly see changes which don't alter the sources but the output itself (filters, asset grouping etc). If it's required, one can use `assetic:list --md5=dump` that generates a hash from asset's dumped output.
