### PR TITLE
Add config for lessrecess filter (for *.less files)

### DIFF
--- a/Resources/config/filters/lessrecess.xml
+++ b/Resources/config/filters/lessrecess.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="assetic.filter.lessrecess.class">Assetic\Filter\LessRecessFilter</parameter>
+        <parameter key="assetic.filter.lessrecess.node">%assetic.node.bin%</parameter>
+        <parameter key="assetic.filter.lessrecess.node_paths">%assetic.node.paths%</parameter>
+        <parameter key="assetic.filter.lessrecess.timeout">null</parameter>
+        <parameter key="assetic.filter.lessrecess.compress">false</parameter>
+    </parameters>
+
+    <services>
+        <service id="assetic.filter.lessrecess" class="%assetic.filter.lessrecess.class%">
+            <tag name="assetic.filter" alias="lessrecess" />
+            <argument>%assetic.filter.lessrecess.node%</argument>
+            <argument>%assetic.filter.lessrecess.node_paths%</argument>
+            <call method="setTimeout"><argument>%assetic.filter.lessrecess.timeout%</argument></call>
+            <call method="setCompress"><argument>%assetic.filter.lessrecess.compress%</argument></call>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Added the lessrecess filter for *.less files. This filter is based on the standard less filter, but is also able to compile Bootstrap 3.0. As of Bootstrap 3.0 the only officially supported compiler is recess.

Requires https://github.com/kriswallsmith/assetic/pull/482
