### PR TITLE
Fix overriding assetic bundle classes

### DIFF
--- a/DependencyInjection/AsseticExtension.php
+++ b/DependencyInjection/AsseticExtension.php
@@ -121,8 +121,8 @@ class AsseticExtension extends Extension
         $container->setParameter('assetic.bundles', $config['bundles']);
 
         $this->addClassesToCompile(array(
-            'Symfony\\Bundle\\AsseticBundle\\DefaultValueSupplier',
-            'Symfony\\Bundle\\AsseticBundle\\Factory\\AssetFactory',
+            $container->getParameter('assetic.value_supplier.class'),
+            $container->getParameter('assetic.asset_factory.class'),
             /* This will introduce hard dependency on Twig
             'Assetic\\Extension\\Twig\\AsseticExtension',
             'Assetic\\Extension\\Twig\\ValueContainer',


### PR DESCRIPTION
I created my own ValueSupplier class to add other variables to assetic. My supplier was not called, I had this in my parameters:

```
assetic.value_supplier.class: My\Bundle\Assetic\CustomValueSupplier
```

With this commit it works, but I'm really not sure this is the right thing to do.
The ultimate goal was to have assetic variables to work in the javascript tag, but had no success. This PR is a step forward to make it work, hopefully.
