### PR TITLE
Fixed fatal error after --watch was deprecated

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -71,7 +71,7 @@ class DumpCommand extends AbstractCommand
             : $stdout;
 
         if ($input->getOption('watch')) {
-            $stderr->output(
+            $stderr->writeln(
                 '<error>The --watch option is deprecated. Please use the '.
                 'assetic:watch command instead.</error>'
             );


### PR DESCRIPTION
``````
> app/console assetic:dump --watch
PHP Fatal error:  Call to undefined method Symfony\Component\Console\Output\StreamOutput::output() in /home/bart/workspace/nitro/vendor/symfony/assetic-bundle/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php on line 74
PHP Stack trace:
PHP   1. {main}() /home/bart/workspace/nitro/app/console:0
PHP   2. Symfony\Component\Console\Application->run() /home/bart/workspace/nitro/app/console:24
PHP   3. Symfony\Bundle\FrameworkBundle\Console\Application->doRun() /home/bart/workspace/nitro/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:121
PHP   4. Symfony\Component\Console\Application->doRun() ```
/home/bart/workspace/nitro/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:96
PHP   5. Symfony\Component\Console\Application->doRunCommand() /home/bart/workspace/nitro/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:191
PHP   6. Symfony\Component\Console\Command\Command->run() /home/bart/workspace/nitro/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:904
PHP   7. Symfony\Bundle\AsseticBundle\Command\DumpCommand->execute() /home/bart/workspace/nitro/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:244
``````
