### PR TITLE
Fix content type on assetic controller responses

### DIFF
--- a/Controller/AsseticController.php
+++ b/Controller/AsseticController.php
@@ -69,6 +69,14 @@ class AsseticController
 
         $this->configureAssetValues($asset);
 
+        // Content-type
+        if (!$response->headers->has('content-type')) {
+            $extension = pathinfo($asset->getTargetPath(), PATHINFO_EXTENSION);
+            $contentType = $this->request->getMimeType($extension);
+
+            $response->headers->set('Content-Type', $contentType);
+        }
+
         // last-modified
         if (null !== $lastModified = $this->am->getLastModified($asset)) {
             $date = new \DateTime();


### PR DESCRIPTION
The AsseticController is not setting the content type on requests which means many browsers will not render correctly (ie if a css file is transferred as text/html).

This pull request fixes #241 and replaces #243.
