### PR TITLE
Add configuration option for language_in of Closure

### DIFF
--- a/Resources/config/filters/closure.xml
+++ b/Resources/config/filters/closure.xml
@@ -10,6 +10,7 @@
         <parameter key="assetic.filter.closure.java">%assetic.java.bin%</parameter>
         <parameter key="assetic.filter.closure.timeout">null</parameter>
         <parameter key="assetic.filter.closure.compilation_level">null</parameter>
+        <parameter key="assetic.filter.closure.language">null</parameter>
     </parameters>
 
     <services>
@@ -19,12 +20,15 @@
             <argument>%assetic.filter.closure.java%</argument>
             <call method="setTimeout"><argument>%assetic.filter.closure.timeout%</argument></call>
             <call method="setCompilationLevel"><argument>%assetic.filter.closure.compilation_level%</argument></call>
+            <call method="setLanguage"><argument>%assetic.filter.closure.language%</argument></call>
+            
         </service>
 
         <service id="assetic.filter.closure.api" class="%assetic.filter.closure.api.class%">
             <tag name="assetic.filter" alias="closure" />
             <call method="setTimeout"><argument>%assetic.filter.closure.timeout%</argument></call>
             <call method="setCompilationLevel"><argument>%assetic.filter.closure.compilation_level%</argument></call>
+            <call method="setLanguage"><argument>%assetic.filter.closure.language%</argument></call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
language: ECMASCRIPT5 under assetic closure config in config.yml

Its a need by closure to compile AngularJS 1.+ properly
