### PR TITLE
Refactored the controller to read variables from the request

### DIFF
--- a/Controller/AsseticController.php
+++ b/Controller/AsseticController.php
@@ -33,7 +33,6 @@ class AsseticController
     protected $cache;
     protected $enableProfiler;
     protected $profiler;
-    protected $valueSupplier;
 
     public function __construct(Request $request, LazyAssetManager $am, CacheInterface $cache, $enableProfiler = false, Profiler $profiler = null)
     {
@@ -46,7 +45,7 @@ class AsseticController
 
     public function setValueSupplier(ValueSupplierInterface $supplier)
     {
-        $this->valueSupplier = $supplier;
+        trigger_error(sprintf('%s is deprecated. The values of asset variables are retrieved from the request after the route matching.', __METHOD__), E_USER_DEPRECATED);
     }
 
     public function render($name, $pos = null)
@@ -105,11 +104,7 @@ class AsseticController
     protected function configureAssetValues(AssetInterface $asset)
     {
         if ($vars = $asset->getVars()) {
-            if (null === $this->valueSupplier) {
-                throw new \RuntimeException(sprintf('You must configure a value supplier if you have assets with variables.'));
-            }
-
-            $asset->setValues(array_intersect_key($this->valueSupplier->getValues(), array_flip($vars)));
+            $asset->setValues(array_intersect_key($this->request->attributes->all(), array_flip($vars)));
         }
 
         return $this;

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -23,10 +23,6 @@
             <argument type="service" id="assetic.cache" />
             <argument>%assetic.enable_profiler%</argument>
             <argument type="service" id="profiler" on-invalid="null" />
-
-            <call method="setValueSupplier">
-                <argument type="service" id="assetic.value_supplier" on-invalid="ignore" />
-            </call>
         </service>
         <service id="assetic.cache" class="%assetic.cache.class%" public="false">
             <argument>%assetic.cache_dir%/assets</argument>

--- a/Tests/Controller/AsseticControllerTest.php
+++ b/Tests/Controller/AsseticControllerTest.php
@@ -178,7 +178,6 @@ class AsseticControllerTest extends \PHPUnit_Framework_TestCase
         $name = 'foo';
         $content = '==ASSET_CONTENT==';
         $formula = array(array('js/core.js'), array(), array(''));
-        $etag = md5(serialize($formula + array('last_modified' => null)));
 
         $asset->expects($this->any())
             ->method('getFilters')


### PR DESCRIPTION
This ensures that the variable values used to dump the asset are the one requested for this url instead of expecting that the value supplier is in the same state than when generating the url for the asset. 
This assumption is already an issue for the default supplier: the symfony environment is likely to be the same, but the request locale is based on matching _locale, not locale. So the controller will generally use the en locale unless a listener changed it.
I discovered this issue when writing a custom value supplier which was not able to give me the right value at all (because the logic setting a special value in it was clearly not triggered in the request loading the asset).

The route definition and the Assetic target path generation already ensure that all variables are part of the request attribute after the route matching.
