### PR TITLE
Added route requirements for the asset variables

### DIFF
--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -16,6 +16,7 @@
         <service id="assetic.routing_loader" class="%assetic.routing_loader.class%" public="false">
             <tag name="routing.loader" />
             <argument type="service" id="assetic.asset_manager" />
+            <argument>%assetic.variables%</argument>
         </service>
         <service id="assetic.controller" class="%assetic.controller.class%" scope="prototype">
             <argument type="service" id="request" />


### PR DESCRIPTION
This is needed to ensure the correct matching of routes. Otherwise, the route for the combined asset `/main.{locale}.js` will be matched when accessing the url for the leaf `/main.en__1.js` for instance, using the wrong value
for the variable (it should be matched by `/main.{locale}__1.js`.
It is also needed to avoid weird restrictions on the allowed values when generating the route. The autogenerated requirement for the variable in the combined url would forbid `/` and `.` (as the next delimiter char is a dot), while the url for the leaf url would forbid `/` and `_` for the last variable. There is no reason to impose such weird restriction on possible variable values.
On the other hand, the list of allowed values is known by the bundle (it is required to allow dumping assets). So we can generate the proper requirement to forbid other values in the url (which would generally break the rendering by trying to access a non-existent file).
