### PR TITLE
MimeType for Opera

### DIFF
--- a/Controller/AsseticController.php
+++ b/Controller/AsseticController.php
@@ -86,6 +86,16 @@ class AsseticController
         if ($response->isNotModified($this->request)) {
             return $response;
         }
+        
+
+        switch (pathinfo($asset->getTargetPath(), PATHINFO_EXTENSION)) {
+            case "css":
+                $response->headers->set("Content-Type", "text/css");
+                break;
+            case "js":
+                $response->headers->set("Content-Type", "application/javascript");
+                break;
+        }
 
         $response->setContent($this->cachifyAsset($asset)->dump());
 


### PR DESCRIPTION
Opera needs MimeType to interpretate css (not sure with js), so i added it based on target file extension.
I'm not 100% sure if it's the best way.
