### PR TITLE
Closure Compiler

### DIFF
--- a/Resources/config/filters/closure.xml
+++ b/Resources/config/filters/closure.xml
@@ -10,6 +10,9 @@
         <parameter key="assetic.filter.closure.java">%assetic.java.bin%</parameter>
         <parameter key="assetic.filter.closure.timeout">null</parameter>
         <parameter key="assetic.filter.closure.compilation_level">null</parameter>
+        <parameter key="assetic.filter.closure.language">null</parameter>
+        <parameter key="assetic.filter.closure.formatting">null</parameter>
+        <parameter key="assetic.filter.closure.warning_level">null</parameter>
     </parameters>
 
     <services>
@@ -19,12 +22,18 @@
             <argument>%assetic.filter.closure.java%</argument>
             <call method="setTimeout"><argument>%assetic.filter.closure.timeout%</argument></call>
             <call method="setCompilationLevel"><argument>%assetic.filter.closure.compilation_level%</argument></call>
+            <call method="setLanguage"><argument>%assetic.filter.closure.language%</argument></call>
+            <call method="setFormatting"><argument>%assetic.filter.closure.formatting%</argument></call>
+            <call method="setWarningLevel"><argument>%assetic.filter.closure.warning_level%</argument></call>
         </service>
 
         <service id="assetic.filter.closure.api" class="%assetic.filter.closure.api.class%">
             <tag name="assetic.filter" alias="closure" />
             <call method="setTimeout"><argument>%assetic.filter.closure.timeout%</argument></call>
             <call method="setCompilationLevel"><argument>%assetic.filter.closure.compilation_level%</argument></call>
+            <call method="setLanguage"><argument>%assetic.filter.closure.language%</argument></call>
+            <call method="setFormatting"><argument>%assetic.filter.closure.formatting%</argument></call>
+            <call method="setWarningLevel"><argument>%assetic.filter.closure.warning_level%</argument></call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Missing options
setLanguage, setFormatting, setWarningLevel
- Allows the usage of --language_in (Compiles AngularJs 1.x and Ember.js with ECMASCRIPT5)
- Allows the usage of --formatting (PRETTY_PRINT etc.)
- Allows the usage of --warning_level (DEFAULT, VERBOSE, QUIET)

Example usage (tested with latest stable ember.js and handlebars.js and Twitter Bootstrap 3.0.x):

```
assetic:
 ...
    filters:
        closure:
            jar: /usr/local/bin/compiler.jar
            compilation_level: SIMPLE_OPTIMIZATIONS
            formatting: PRETTY_PRINT
            language: ECMASCRIPT5
            #warning_level: DEFAULT 
            apply_to: "\.js$"
```

```
            {% javascripts filter='?closure' output='js/compiled-ember.js'
            '@YourBundle/Resources/public/js/handlebars-v1.2.0.js'
            '@YourBundle/Resources/public/js/ember.js'
            '@YourBundle/Resources/public/js/ember-data.js'

            %}
            <script type="application/javascript" src="{{ asset_url }}"></script>
            {% endjavascripts %}
```
