### PR TITLE
Added EmberPrecompile filter.

### DIFF
--- a/Resources/config/filters/emberprecompile.xml
+++ b/Resources/config/filters/emberprecompile.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="assetic.filter.emberprecompile.class">Assetic\Filter\EmberPrecompileFilter</parameter>
+        <parameter key="assetic.filter.emberprecompile.bin">/usr/bin/ember-precompile</parameter>
+        <parameter key="assetic.filter.emberprecompile.node">%assetic.node.bin%</parameter>
+        <parameter key="assetic.filter.emberprecompile.timeout">null</parameter>
+        <parameter key="assetic.filter.emberprecompile.node_paths">%assetic.node.paths%</parameter>
+    </parameters>
+
+    <services>
+        <service id="assetic.filter.emberprecompile" class="%assetic.filter.emberprecompile.class%">
+            <tag name="assetic.filter" alias="emberprecompile" />
+            <argument>%assetic.filter.emberprecompile.bin%</argument>
+            <argument>%assetic.filter.emberprecompile.node%</argument>
+            <call method="setTimeout"><argument>%assetic.filter.emberprecompile.timeout%</argument></call>
+            <call method="setNodePaths"><argument>%assetic.filter.emberprecompile.node_paths%</argument></call>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Ability to use ember-precompile to precompile handlebar templates for usage with Ember.js.

Tested with stable release of Ember.js 1.2.0, Handlebars.js 1.2.1

Example configuration:

```
assetic:
    ....
    filters:
        cssrewrite: ~
        emberprecompile:
            bin: /usr/local/bin/ember-precompile
            apply_to: "\.hbs$"
```

```
            {% javascripts filter='?emberprecompile' output='js/compiled-handlebars.js'
            '@YourBundle/Resources/public/hbs/application.hbs'
            '@YourBundle/Resources/public/hbs/index.hbs'
            %}
            <script type="application/javascript" src="{{ asset_url }}"></script>
            {% endjavascripts %}
```

Install by using the following command-line:

```
npm install ember-precompile -g
```
