### PR TITLE
Fix controller response Content-Type header

### DIFF
--- a/Controller/AsseticController.php
+++ b/Controller/AsseticController.php
@@ -68,6 +68,15 @@ class AsseticController
 
         $this->configureAssetValues($asset);
 
+        // content-type
+        if (!$response->headers->has('content-type')) {
+            $extension = pathinfo($asset->getTargetPath(), PATHINFO_EXTENSION);
+            $contentType = $this->request->getMimeType($extension);
+            if (null !== $contentType) {
+                $response->headers->set('Content-Type', $contentType);
+            }
+        }
+
         // last-modified
         if (null !== $lastModified = $this->am->getLastModified($asset)) {
             $date = new \DateTime();


### PR DESCRIPTION
The AsseticController is not setting the content type on requests which means many browsers will not render correctly (ie if a css file is transferred as text/html).

This pull request fixes #241 and replaces #243, #245 and #252 .

It's almost the same as #245 but with unit tests.
