### PR TITLE
add ability to set cache_location for compass via configuration

### DIFF
--- a/Resources/config/filters/compass.xml
+++ b/Resources/config/filters/compass.xml
@@ -23,6 +23,7 @@
         <parameter key="assetic.filter.compass.plugins" type="collection" />
         <parameter key="assetic.filter.compass.load_paths" type="collection" />
         <parameter key="assetic.filter.compass.home_env">true</parameter>
+        <parameter key="assetic.filter.compass.cache_location">%kernel.cache_dir%</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
Also see kriswallsmith/assetic/issues/268

How to use it:

```
# app/config/config.yml
...
# assetic configuration
assetic:
    filters:
        compass:
            cache_location: %kernel.cache_dir%
...
```
