### PR TITLE
Clear PHP file stat cache on each watch iteration

### DIFF
--- a/Command/WatchCommand.php
+++ b/Command/WatchCommand.php
@@ -80,6 +80,7 @@ class WatchCommand extends AbstractCommand
                     $error = $msg;
                 }
             }
+
             clearstatcache ();
             sleep($input->getOption('period'));
         }


### PR DESCRIPTION
PHP caches all `stat` calls.

The PHP clears the cache on each write operation, but the `dump` command has not write operations, so the cache is never cleared.

The `clearstatcache` is explained here http://php.net/manual/en/function.clearstatcache.php
