### PR TITLE
add symfony/validator to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "symfony/class-loader": "~2.1",
         "symfony/yaml": "~2.1",
         "symfony/form": "~2.1",
+        "symfony/validator": "~2.1",
         "symfony/dom-crawler": "~2.1",
         "symfony/css-selector": "~2.1"
     },


### PR DESCRIPTION
to prevent 

> PHP Fatal error:  Class 'Symfony\Component\Validator\Validation' not found in Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php on line 750 

when running phpunit
