### PR TITLE
language_in config parameter to closure filter.

### DIFF
--- a/Resources/config/filters/closure.xml
+++ b/Resources/config/filters/closure.xml
@@ -10,6 +10,7 @@
         <parameter key="assetic.filter.closure.java">%assetic.java.bin%</parameter>
         <parameter key="assetic.filter.closure.timeout">null</parameter>
         <parameter key="assetic.filter.closure.compilation_level">null</parameter>
+        <parameter key="assetic.filter.closure.language_in">null</parameter>
     </parameters>
 
     <services>
@@ -19,12 +20,14 @@
             <argument>%assetic.filter.closure.java%</argument>
             <call method="setTimeout"><argument>%assetic.filter.closure.timeout%</argument></call>
             <call method="setCompilationLevel"><argument>%assetic.filter.closure.compilation_level%</argument></call>
+            <call method="setLanguage"><argument>%assetic.filter.closure.language_in%</argument></call>
         </service>
 
         <service id="assetic.filter.closure.api" class="%assetic.filter.closure.api.class%">
             <tag name="assetic.filter" alias="closure" />
             <call method="setTimeout"><argument>%assetic.filter.closure.timeout%</argument></call>
             <call method="setCompilationLevel"><argument>%assetic.filter.closure.compilation_level%</argument></call>
+            <call method="setLanguage"><argument>%assetic.filter.closure.language_in%</argument></call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Assetic supports setting the language_in command line flag of Google Closure Compiler, this feature is needed in AsseticBundle too.
