### PR TITLE
Allow configuration of sass/scss filter cache location folders.

### DIFF
--- a/Resources/config/filters/sass.xml
+++ b/Resources/config/filters/sass.xml
@@ -11,6 +11,7 @@
         <parameter key="assetic.filter.sass.style">null</parameter>
         <parameter key="assetic.filter.sass.compass">null</parameter>
         <parameter key="assetic.filter.sass.load_paths" type="collection" />
+        <parameter key="assetic.filter.sass.cache_location">%kernel.cache_dir%</parameter>
     </parameters>
 
     <services>
@@ -22,6 +23,7 @@
             <call method="setStyle"><argument>%assetic.filter.sass.style%</argument></call>
             <call method="setCompass"><argument>%assetic.filter.sass.compass%</argument></call>
             <call method="setLoadPaths"><argument>%assetic.filter.sass.load_paths%</argument></call>
+            <call method="setCacheLocation"><argument>%assetic.filter.sass.cache_location%</argument></call>
         </service>
     </services>
 </container>

--- a/Resources/config/filters/scss.xml
+++ b/Resources/config/filters/scss.xml
@@ -13,6 +13,7 @@
         <parameter key="assetic.filter.scss.load_paths" type="collection">
             <parameter>%kernel.root_dir%/../web</parameter>
         </parameter>
+        <parameter key="assetic.filter.scss.cache_location">%kernel.cache_dir%</parameter>
     </parameters>
 
     <services>
@@ -24,6 +25,7 @@
             <call method="setStyle"><argument>%assetic.filter.scss.style%</argument></call>
             <call method="setCompass"><argument>%assetic.filter.scss.compass%</argument></call>
             <call method="setLoadPaths"><argument>%assetic.filter.scss.load_paths%</argument></call>
+            <call method="setCacheLocation"><argument>%assetic.filter.scss.cache_location%</argument></call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Add the same functionality of being able to configure the cache location for sass/scss filters as was added for compass in https://github.com/symfony/AsseticBundle/pull/270
