### PR TITLE
Update RequestListener to add format for SVG files

### DIFF
--- a/EventListener/RequestListener.php
+++ b/EventListener/RequestListener.php
@@ -27,5 +27,6 @@ class RequestListener
         $request->setFormat('png', 'image/png');
         $request->setFormat('jpg', 'image/jpeg');
         $request->setFormat('gif', 'image/gif');
+        $request->setFormat('svg', 'image/svg+xml');
     }
 }


### PR DESCRIPTION
I was just working on a project of my own and realized svg files don't display properly when served through assetic because of the incorrect mime-type.

I think the correct way would be to perhaps set the format in the request using the MimeTypeGuesser for assetic responses instead of adding each of the possible formats.
