### PR TITLE
Updated the Assetic commands to the new Symfony style

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -85,7 +85,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
             $target = VarUtils::resolve($target, $asset->getVars(), $asset->getValues());
 
             if (!is_dir($dir = dirname($target))) {
-                $stdout->writeln(sprintf(
+                $stdout->text(sprintf(
                     '<comment>%s</comment> <info>[dir+]</info> %s',
                     date('H:i:s'),
                     $dir
@@ -96,7 +96,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
                 }
             }
 
-            $stdout->writeln(sprintf(
+            $stdout->text(sprintf(
                 '<comment>%s</comment> <info>[file+]</info> %s',
                 date('H:i:s'),
                 $target
@@ -107,12 +107,12 @@ abstract class AbstractCommand extends ContainerAwareCommand
                     foreach ($asset as $leaf) {
                         $root = $leaf->getSourceRoot();
                         $path = $leaf->getSourcePath();
-                        $stdout->writeln(sprintf('        <comment>%s/%s</comment>', $root ?: '[unknown root]', $path ?: '[unknown path]'));
+                        $stdout->comment(sprintf('  <comment>%s/%s</comment>', $root ?: '[unknown root]', $path ?: '[unknown path]'));
                     }
                 } else {
                     $root = $asset->getSourceRoot();
                     $path = $asset->getSourcePath();
-                    $stdout->writeln(sprintf('        <comment>%s/%s</comment>', $root ?: '[unknown root]', $path ?: '[unknown path]'));
+                    $stdout->comment(sprintf('  <comment>%s/%s</comment>', $root ?: '[unknown root]', $path ?: '[unknown path]'));
                 }
             }
 

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Dumps assets to the filesystem.
@@ -61,21 +62,17 @@ class DumpCommand extends AbstractCommand
             );
         }
 
+        $stdout = new SymfonyStyle($input, $stdout);
+
         parent::initialize($input, $stdout);
     }
 
     protected function execute(InputInterface $input, OutputInterface $stdout)
     {
-        // capture error output
-        $stderr = $stdout instanceof ConsoleOutputInterface
-            ? $stdout->getErrorOutput()
-            : $stdout;
+        $stdout = new SymfonyStyle($input, $stdout);
 
         if ($input->getOption('watch')) {
-            $stderr->writeln(
-                '<error>The --watch option is deprecated. Please use the '.
-                'assetic:watch command instead.</error>'
-            );
+            $stdout->caution('The --watch option is deprecated. Please use the assetic:watch command instead.');
 
             // build assetic:watch arguments
             $arguments = array(
@@ -99,9 +96,9 @@ class DumpCommand extends AbstractCommand
         }
 
         // print the header
-        $stdout->writeln(sprintf('Dumping all <comment>%s</comment> assets.', $input->getOption('env')));
-        $stdout->writeln(sprintf('Debug mode is <comment>%s</comment>.', $this->am->isDebug() ? 'on' : 'off'));
-        $stdout->writeln('');
+        $stdout->comment(sprintf('Dumping all <comment>%s</comment> assets.', $input->getOption('env')));
+        $stdout->comment(sprintf('Debug mode is <comment>%s</comment>.', $this->am->isDebug() ? 'on' : 'off'));
+        $stdout->newLine();
 
         if ($this->spork) {
             $batch = $this->spork->createBatchJob(

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Dumps assets to the filesystem.
@@ -44,7 +43,7 @@ class DumpCommand extends AbstractCommand
         ;
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $stdout)
+    protected function initialize(InputInterface $input, OutputInterface $output)
     {
         if (null !== $input->getOption('forks')) {
             if (!class_exists('Spork\ProcessManager')) {
@@ -62,17 +61,13 @@ class DumpCommand extends AbstractCommand
             );
         }
 
-        $stdout = new SymfonyStyle($input, $stdout);
-
-        parent::initialize($input, $stdout);
+        parent::initialize($input, $output);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $stdout)
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $stdout = new SymfonyStyle($input, $stdout);
-
         if ($input->getOption('watch')) {
-            $stdout->caution('The --watch option is deprecated. Please use the assetic:watch command instead.');
+            $this->io->caution('The --watch option is deprecated. Please use the assetic:watch command instead.');
 
             // build assetic:watch arguments
             $arguments = array(
@@ -96,9 +91,9 @@ class DumpCommand extends AbstractCommand
         }
 
         // print the header
-        $stdout->comment(sprintf('Dumping all <comment>%s</comment> assets.', $input->getOption('env')));
-        $stdout->comment(sprintf('Debug mode is <comment>%s</comment>.', $this->am->isDebug() ? 'on' : 'off'));
-        $stdout->newLine();
+        $this->io->comment(sprintf('Dumping all <comment>%s</comment> assets.', $input->getOption('env')));
+        $this->io->comment(sprintf('Debug mode is <comment>%s</comment>.', $this->am->isDebug() ? 'on' : 'off'));
+        $this->io->newLine();
 
         if ($this->spork) {
             $batch = $this->spork->createBatchJob(
@@ -107,12 +102,12 @@ class DumpCommand extends AbstractCommand
             );
 
             $self = $this;
-            $batch->execute(function ($name) use ($self, $stdout) {
+            $batch->execute(function ($name) use ($self, $output) {
                 $self->dumpAsset($name, $stdout);
             });
         } else {
             foreach ($this->am->getNames() as $name) {
-                $this->dumpAsset($name, $stdout);
+                $this->dumpAsset($name, $output);
             }
         }
     }

--- a/Command/WatchCommand.php
+++ b/Command/WatchCommand.php
@@ -37,14 +37,12 @@ class WatchCommand extends AbstractCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $stdout)
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $stdout = new SymfonyStyle($input, $stdout);
-
         // print the header
-        $stdout->comment(sprintf('Dumping all <comment>%s</comment> assets.', $input->getOption('env')));
-        $stdout->comment(sprintf('Debug mode is <comment>%s</comment>.', $this->am->isDebug() ? 'on' : 'off'));
-        $stdout->newLine();
+        $this->io->comment(sprintf('Dumping all <comment>%s</comment> assets.', $input->getOption('env')));
+        $this->io->comment(sprintf('Debug mode is <comment>%s</comment>.', $this->am->isDebug() ? 'on' : 'off'));
+        $this->io->newLine();
 
         // establish a temporary status file
         $cache = sys_get_temp_dir().'/assetic_watch_'.substr(sha1($this->basePath), 0, 7);
@@ -62,7 +60,7 @@ class WatchCommand extends AbstractCommand
             try {
                 foreach ($this->am->getNames() as $name) {
                     if ($this->checkAsset($name, $previously)) {
-                        $this->dumpAsset($name, $stdout);
+                        $this->dumpAsset($name, $output);
                     }
                 }
 
@@ -74,7 +72,7 @@ class WatchCommand extends AbstractCommand
                 $error = '';
             } catch (\Exception $e) {
                 if ($error != $msg = $e->getMessage()) {
-                    $stdout->error($msg);
+                    $output->error($msg);
                     $error = $msg;
                 }
             }

--- a/Command/WatchCommand.php
+++ b/Command/WatchCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Dumps assets as their source files are modified.
@@ -38,15 +39,12 @@ class WatchCommand extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $stdout)
     {
-        // capture error output
-        $stderr = $stdout instanceof ConsoleOutputInterface
-            ? $stdout->getErrorOutput()
-            : $stdout;
+        $stdout = new SymfonyStyle($input, $stdout);
 
         // print the header
-        $stdout->writeln(sprintf('Dumping all <comment>%s</comment> assets.', $input->getOption('env')));
-        $stdout->writeln(sprintf('Debug mode is <comment>%s</comment>.', $this->am->isDebug() ? 'on' : 'off'));
-        $stdout->writeln('');
+        $stdout->comment(sprintf('Dumping all <comment>%s</comment> assets.', $input->getOption('env')));
+        $stdout->comment(sprintf('Debug mode is <comment>%s</comment>.', $this->am->isDebug() ? 'on' : 'off'));
+        $stdout->newLine();
 
         // establish a temporary status file
         $cache = sys_get_temp_dir().'/assetic_watch_'.substr(sha1($this->basePath), 0, 7);
@@ -76,7 +74,7 @@ class WatchCommand extends AbstractCommand
                 $error = '';
             } catch (\Exception $e) {
                 if ($error != $msg = $e->getMessage()) {
-                    $stderr->writeln('<error>[error]</error> '.$msg);
+                    $stdout->error($msg);
                     $error = $msg;
                 }
             }


### PR DESCRIPTION
The output of these commands is very special, so the changes are not really that noticeable:
### assetic:dump

![assetic_dump](https://cloud.githubusercontent.com/assets/73419/10134041/f2197d9c-65e2-11e5-8f73-856ad5c526fc.png)
### assetic:watch

![assetic_watch](https://cloud.githubusercontent.com/assets/73419/10134044/fb25d9f8-65e2-11e5-8032-120d14ae60b8.png)
