### PR TITLE
[WIP] made AsseticBundle work when templating is disabled and only Twig is enabled

### DIFF
--- a/DependencyInjection/Compiler/TemplateResourcesPass.php
+++ b/DependencyInjection/Compiler/TemplateResourcesPass.php
@@ -29,7 +29,11 @@ class TemplateResourcesPass implements CompilerPassInterface
             return;
         }
 
-        $engines = $container->getParameter('templating.engines');
+        if (!$container->hasParameter('templating.engines')) {
+            $engines = array('twig');
+        } else {
+            $engines = $container->getParameter('templating.engines');
+        }
 
         // bundle and kernel resources
         $bundles = $container->getParameter('kernel.bundles');

--- a/DependencyInjection/Compiler/TemplatingPass.php
+++ b/DependencyInjection/Compiler/TemplatingPass.php
@@ -27,7 +27,11 @@ class TemplatingPass implements CompilerPassInterface
             return;
         }
 
-        $engines = $container->getParameterBag()->resolveValue($container->getParameter('templating.engines'));
+        if (!$container->hasParameter('templating.engines')) {
+            $engines = array('twig');
+        } else {
+            $engines = $container->getParameterBag()->resolveValue($container->getParameter('templating.engines'));
+        }
 
         if (!in_array('twig', $engines)) {
             foreach ($container->findTaggedServiceIds('assetic.templating.twig') as $id => $attr) {


### PR DESCRIPTION
I've started to see how to make the bundle compatible with a Symfony project where Twig is used without the templating sub-system. It turns out that it's going to be complex. So, I'm pushing this first step, which far from being enough. Reading through the code, I can see many weird/smart (your choice) use of some Symfony features.

So, the question is: is it worth it? Seeing the answers on Twitter, I think I won't spend too much on this: https://twitter.com/fabpot/status/648520881145253888