### PR TITLE
Dump Command: detect errors on forked processes

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -110,9 +110,16 @@ class DumpCommand extends AbstractCommand
             );
 
             $self = $this;
-            $batch->execute(function ($name) use ($self, $stdout) {
+            $promise = $batch->execute(function ($name) use ($self, $stdout) {
                 $self->dumpAsset($name, $stdout);
             });
+
+            $promise->wait();
+
+            $promise->fail(function () {
+                throw new \RuntimeException('Dump failed!');
+            });
+
         } else {
             foreach ($this->am->getNames() as $name) {
                 $this->dumpAsset($name, $stdout);


### PR DESCRIPTION
When parallel dumping is used, the command was not able to detect any errors during the computation.

Warning: this fix actually works only if the related bug on Spork will be fixed (PR https://github.com/kriswallsmith/spork/pull/36 )
