### PR TITLE
Make $spork more accessible

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -28,7 +28,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DumpCommand extends AbstractCommand
 {
-    private $spork;
+    protected $spork;
 
     protected function configure()
     {


### PR DESCRIPTION
Now it's impossible to hook on `Spork` batch finish to do some other necessary stuff after `assetic:dump` is completed.