### PR TITLE
Fixing 3.0 compatibility problem with ResourceInterface::isFresh()

### DIFF
--- a/Config/SelfCheckingAsseticResource.php
+++ b/Config/SelfCheckingAsseticResource.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Config;
+
+use Symfony\Component\Config\Resource\SelfCheckingResourceInterface;
+
+/**
+ * Implements SelfCheckingResourceInterface required in Symfony 3.0.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ *
+ * @internal
+ */
+class SelfCheckingAsseticResource extends AsseticResource implements SelfCheckingResourceInterface
+{
+}

--- a/Routing/AsseticLoader.php
+++ b/Routing/AsseticLoader.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\AsseticBundle\Routing;
 use Assetic\Asset\AssetInterface;
 use Assetic\Factory\LazyAssetManager;
 use Symfony\Bundle\AsseticBundle\Config\AsseticResource;
+use Symfony\Bundle\AsseticBundle\Config\SelfCheckingAsseticResource;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -56,7 +57,12 @@ class AsseticLoader extends Loader
                 $resources = array($resources);
             }
             foreach ($resources as $resource) {
-                $routes->addResource(new AsseticResource($resource));
+                if (interface_exists('Symfony\Component\Config\Resource\SelfCheckingResourceInterface')) {
+                    $routes->addResource(new SelfCheckingAsseticResource($resource));
+                } else {
+                    // for BC with symfony/config 2.7 and lower
+                    $routes->addResource(new AsseticResource($resource));
+                }
             }
         }
 


### PR DESCRIPTION
Hi guys!

The bundle is not ready for 3.0 yet, because of [AsseticResource](https://github.com/symfony/assetic-bundle/blob/master/Config/AsseticResource.php). Implementing `isFresh()` on `ResourceInterface` is deprecated: we need to also implement `SelfCheckingResourceInterface`.

But this patch clearly has issues: it makes AsseticBundle require symfony/config 2.8 (and worse, beta currently). Is there a way to make the bundle compatible with 2.7 (where `SelfCheckingResourceInterface` doesn't exist) AND 3.0 (where `SelfCheckingResourceInterface` is required) at the same time?

Thanks!