### PR TITLE
fix request in DefaultValueSupplier

### DIFF
--- a/DefaultValueSupplier.php
+++ b/DefaultValueSupplier.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\AsseticBundle;
 
 use Assetic\ValueSupplierInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Default Value Supplier.
@@ -23,18 +24,21 @@ class DefaultValueSupplier implements ValueSupplierInterface
 {
     protected $container;
 
-    public function __construct(ContainerInterface $container)
+    protected $requestStack;
+
+    public function __construct(ContainerInterface $container, RequestStack $requestStack)
     {
         $this->container = $container;
+        $this->requestStack = $requestStack;
     }
 
     public function getValues()
     {
-        if (!$this->container->isScopeActive('request')) {
+        if (!$this->requestStack->getCurrentRequest()) {
             return array();
         }
 
-        $request = $this->container->get('request');
+        $request = $this->requestStack->getCurrentRequest();
 
         return array(
             'locale' => $request->getLocale(),

--- a/DefaultValueSupplier.php
+++ b/DefaultValueSupplier.php
@@ -26,7 +26,7 @@ class DefaultValueSupplier implements ValueSupplierInterface
 
     private $requestStack;
 
-    public function __construct(ContainerInterface $container, RequestStack $requestStack)
+    public function __construct(ContainerInterface $container, RequestStack $requestStack = null)
     {
         $this->container = $container;
         $this->requestStack = $requestStack;
@@ -34,15 +34,31 @@ class DefaultValueSupplier implements ValueSupplierInterface
 
     public function getValues()
     {
-        if (!$this->requestStack->getCurrentRequest()) {
+        $request = $this->getCurrentRequest();
+
+        if (!$request) {
             return array();
         }
-
-        $request = $this->requestStack->getCurrentRequest();
 
         return array(
             'locale' => $request->getLocale(),
             'env'    => $this->container->getParameter('kernel.environment'),
         );
+    }
+
+    /**
+     * @return null|\Symfony\Component\HttpFoundation\Request
+     */
+    private function getCurrentRequest()
+    {
+        $request = null;
+
+        if ($this->requestStack) {
+            $request = $this->requestStack->getCurrentRequest();
+        } elseif ($this->container->isScopeActive('request')) {
+            $request = $this->container->get('request');
+        }
+
+        return $request;
     }
 }

--- a/DefaultValueSupplier.php
+++ b/DefaultValueSupplier.php
@@ -24,7 +24,7 @@ class DefaultValueSupplier implements ValueSupplierInterface
 {
     protected $container;
 
-    protected $requestStack;
+    private $requestStack;
 
     public function __construct(ContainerInterface $container, RequestStack $requestStack)
     {

--- a/DefaultValueSupplier.php
+++ b/DefaultValueSupplier.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\AsseticBundle;
 
 use Assetic\ValueSupplierInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Default Value Supplier.
@@ -24,12 +23,9 @@ class DefaultValueSupplier implements ValueSupplierInterface
 {
     protected $container;
 
-    private $requestStack;
-
-    public function __construct(ContainerInterface $container, RequestStack $requestStack = null)
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
-        $this->requestStack = $requestStack;
     }
 
     public function getValues()
@@ -52,9 +48,10 @@ class DefaultValueSupplier implements ValueSupplierInterface
     private function getCurrentRequest()
     {
         $request = null;
+        $requestStack = $this->container->get('request_stack', ContainerInterface::NULL_ON_INVALID_REFERENCE);
 
-        if ($this->requestStack) {
-            $request = $this->requestStack->getCurrentRequest();
+        if ($requestStack) {
+            $request = $requestStack->getCurrentRequest();
         } elseif ($this->container->isScopeActive('request')) {
             $request = $this->container->get('request');
         }

--- a/Resources/config/assetic.xml
+++ b/Resources/config/assetic.xml
@@ -71,7 +71,7 @@
 
         <service id="assetic.value_supplier.default" class="%assetic.value_supplier.class%" public="false">
             <argument type="service" id="service_container" />
-            <argument type="service" id="request_stack" />
+            <argument type="service" id="request_stack" on-invalid="ignore"/>
         </service>
 
         <service id="assetic.value_supplier" alias="assetic.value_supplier.default" public="false" />

--- a/Resources/config/assetic.xml
+++ b/Resources/config/assetic.xml
@@ -71,7 +71,6 @@
 
         <service id="assetic.value_supplier.default" class="%assetic.value_supplier.class%" public="false">
             <argument type="service" id="service_container" />
-            <argument type="service" id="request_stack" on-invalid="ignore"/>
         </service>
 
         <service id="assetic.value_supplier" alias="assetic.value_supplier.default" public="false" />

--- a/Resources/config/assetic.xml
+++ b/Resources/config/assetic.xml
@@ -71,6 +71,7 @@
 
         <service id="assetic.value_supplier.default" class="%assetic.value_supplier.class%" public="false">
             <argument type="service" id="service_container" />
+            <argument type="service" id="request_stack" />
         </service>
 
         <service id="assetic.value_supplier" alias="assetic.value_supplier.default" public="false" />


### PR DESCRIPTION
In Symfony 3 the service 'request' has been removed from the container, and the function isScopeActive doesn't exist anymore. With this fix the Request Stack is injected in DefaultValueSupplier to get the request.