### PR TITLE
make DefaultValueSupplier compatible with Symfony 3.0

### DIFF
--- a/DefaultValueSupplier.php
+++ b/DefaultValueSupplier.php
@@ -30,11 +30,17 @@ class DefaultValueSupplier implements ValueSupplierInterface
 
     public function getValues()
     {
-        if (!$this->container->isScopeActive('request')) {
-            return array();
+        if ($this->container->has('request_stack')) {
+            $request = $this->container->get('request_stack')->getCurrentRequest();
+            if (null === $request) {
+                return array();
+            }
+        } else {
+            if (!$this->container->isScopeActive('request')) {
+                return array();
+            }
+            $request = $this->container->get('request');
         }
-
-        $request = $this->container->get('request');
 
         return array(
             'locale' => $request->getLocale(),


### PR DESCRIPTION
This fixes #404. It will use `request_stack` whenever available. To maintain compatibility with Symfony 2.3, it falls back to check for `isScopeActive()` if no `request_stack` is found. 
