### PR TITLE
Remove cache-busting from controller

### DIFF
--- a/Controller/AsseticController.php
+++ b/Controller/AsseticController.php
@@ -63,7 +63,7 @@ class AsseticController
         }
 
         $response = $this->createResponse();
-        $response->setExpires(new \DateTime());
+        $response->headers->addCacheControlDirective('public');
 
         $this->configureAssetValues($asset, $request);
 


### PR DESCRIPTION
In PR #33 a cache-busting Expires header was added to the controller. This makes the browser issue a If-Modified-Since request for all resources rather than using the browser cache.

This makes no difference if you Cmd/Ctrl+R reload a page. In this case, the browser always revalidates all resources. But if you just follow a link from one page to another, this change will allow the browser to fetch the assets from the browser cache and thus make browsing the site considerably faster.

Removing the Expires header makes the asset behave like a static file stored on the web server. As mentioned, Cmd+R reloading the page will fetch the updated version of the files. Or if you are using Firebug/Chrome Developer Tools you can check the "Disable cache" checkbox and bypass the browser cache altogether. So there seems to be little reason for applying a more aggressive cache busting strategy for Assetic assets than for static files on web servers in general.

The reasoning behind adding the Expires header in PR #33 was that it was needed to override the Expires headers added by Apache mod_expires. This seems to be the wrong fix for the problem. Using mod_expires to add cache headers to your dev site seems like a bad idea.
