### PR TITLE
fix the 'Symfony\Component\Config\Resource\ResourceInterface' dependence

### DIFF
--- a/Config/AsseticResource.php
+++ b/Config/AsseticResource.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\AsseticBundle\Config;
 
 use Assetic\Factory\Resource\ResourceInterface as AsseticResourceInterface;
-use Symfony\Component\Config\Resource\ResourceInterface as SymfonyResourceInterface;
+use Symfony\Bundle\AsseticBundle\Config\SelfCheckingResourceInterface as SymfonyResourceInterface;
 
 /**
  * Turns an Assetic resource into a Symfony one.


### PR DESCRIPTION
In Symfony 2.8.2 this dependence generate over than 4000 logs of deprecation.