### PR TITLE
Add missing serializable interface

### DIFF
--- a/Config/AsseticResource.php
+++ b/Config/AsseticResource.php
@@ -19,7 +19,7 @@ use Symfony\Component\Config\Resource\ResourceInterface as SymfonyResourceInterf
  *
  * @author Kris Wallsmith <kris@symfony.com>
  */
-class AsseticResource implements SymfonyResourceInterface
+class AsseticResource implements SymfonyResourceInterface, \Serializable
 {
     private $resource;
 


### PR DESCRIPTION
The `AsseticResource` class has `serialize` and `unserialize` methods, but it doesn't implement the `Serializable` interface.
