### PR TITLE
Fixed deprecated addClassesToCompile function

### DIFF
--- a/DependencyInjection/AsseticExtension.php
+++ b/DependencyInjection/AsseticExtension.php
@@ -130,16 +130,18 @@ class AsseticExtension extends Extension
         }
 
         $container->setParameter('assetic.bundles', $config['bundles']);
-
-        $this->addClassesToCompile(array(
-            'Symfony\\Bundle\\AsseticBundle\\DefaultValueSupplier',
-            'Symfony\\Bundle\\AsseticBundle\\Factory\\AssetFactory',
-            /* This will introduce hard dependency on Twig
-            'Assetic\\Extension\\Twig\\AsseticExtension',
-            'Assetic\\Extension\\Twig\\ValueContainer',
-            'Symfony\\Bundle\\AsseticBundle\\Twig\\AsseticExtension',
-            */
-        ));
+        
+        if (\PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                'Symfony\\Bundle\\AsseticBundle\\DefaultValueSupplier',
+                'Symfony\\Bundle\\AsseticBundle\\Factory\\AssetFactory',
+                /* This will introduce hard dependency on Twig
+                'Assetic\\Extension\\Twig\\AsseticExtension',
+                'Assetic\\Extension\\Twig\\ValueContainer',
+                'Symfony\\Bundle\\AsseticBundle\\Twig\\AsseticExtension',
+                */
+            ));
+        }
 
         if ($config['workers']['cache_busting']['enabled']) {
             $container->getDefinition('assetic.worker.cache_busting')->addTag('assetic.factory_worker');


### PR DESCRIPTION
addClassesToCompile within the extensions load function has been deprecated since Symfony 3.3

[https://github.com/symfony/symfony/blob/master/UPGRADE-3.3.md#httpkernel](https://github.com/symfony/symfony/blob/master/UPGRADE-3.3.md#httpkernel) `Symfony\Component\HttpKernel\DependencyInjection\Extension::addClassesToCompile() is deprecated since version 3.3, to be removed in 4.0.`