### PR TITLE
Exclude tests from Composer's classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,10 @@
         "kriswallsmith/spork": "to be able to dump assets in parallel"
     },
     "autoload": {
-        "psr-4": { "Symfony\\Bundle\\AsseticBundle\\": "" }
+        "psr-4": { "Symfony\\Bundle\\AsseticBundle\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This is a little performance improvement. If the optimised dumped classmap is generated, the tests should not be part of it.

Documentation: https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps