### PR TITLE
Fix deprecations when updating to S3.4, set req. services as public

### DIFF
--- a/Resources/config/assetic.xml
+++ b/Resources/config/assetic.xml
@@ -26,11 +26,11 @@
 
     <services>
         <!-- managers -->
-        <service id="assetic.filter_manager" class="%assetic.filter_manager.class%">
+        <service id="assetic.filter_manager" class="%assetic.filter_manager.class%" public="true">
             <argument type="service" id="service_container" />
             <argument type="collection"></argument>
         </service>
-        <service id="assetic.asset_manager" class="%assetic.asset_manager.class%">
+        <service id="assetic.asset_manager" class="%assetic.asset_manager.class%" public="true">
             <argument type="service" id="assetic.asset_factory" />
             <argument type="collection"></argument>
         </service>

--- a/Resources/config/filters/autoprefixer.xml
+++ b/Resources/config/filters/autoprefixer.xml
@@ -12,7 +12,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.autoprefixer" class="Assetic\Filter\AutoprefixerFilter">
+        <service id="assetic.filter.autoprefixer" class="Assetic\Filter\AutoprefixerFilter" public="true">
             <tag name="assetic.filter" alias="autoprefixer" />
             <argument>%assetic.filter.autoprefixer.bin%</argument>
             <call method="setTimeout"><argument>%assetic.filter.autoprefixer.timeout%</argument></call>

--- a/Resources/config/filters/cleancss.xml
+++ b/Resources/config/filters/cleancss.xml
@@ -32,7 +32,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.cleancss" class="%assetic.filter.cleancss.class%">
+        <service id="assetic.filter.cleancss" class="%assetic.filter.cleancss.class%" public="true">
             <tag name="assetic.filter" alias="cleancss" />
             <argument>%assetic.filter.cleancss.bin%</argument>
             <argument>%assetic.filter.cleancss.node%</argument>

--- a/Resources/config/filters/closure.xml
+++ b/Resources/config/filters/closure.xml
@@ -16,7 +16,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.closure.jar" class="%assetic.filter.closure.jar.class%">
+        <service id="assetic.filter.closure.jar" class="%assetic.filter.closure.jar.class%" public="true">
             <tag name="assetic.filter" alias="closure" />
             <argument>%assetic.filter.closure.jar%</argument>
             <argument>%assetic.filter.closure.java%</argument>
@@ -27,7 +27,7 @@
             <call method="setWarningLevel"><argument>%assetic.filter.closure.warning_level%</argument></call>
         </service>
 
-        <service id="assetic.filter.closure.api" class="%assetic.filter.closure.api.class%">
+        <service id="assetic.filter.closure.api" class="%assetic.filter.closure.api.class%" public="true">
             <tag name="assetic.filter" alias="closure" />
             <call method="setTimeout"><argument>%assetic.filter.closure.timeout%</argument></call>
             <call method="setCompilationLevel"><argument>%assetic.filter.closure.compilation_level%</argument></call>

--- a/Resources/config/filters/coffee.xml
+++ b/Resources/config/filters/coffee.xml
@@ -15,7 +15,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.coffee" class="%assetic.filter.coffee.class%">
+        <service id="assetic.filter.coffee" class="%assetic.filter.coffee.class%" public="true">
             <tag name="assetic.filter" alias="coffee" />
             <argument>%assetic.filter.coffee.bin%</argument>
             <argument>%assetic.filter.coffee.node%</argument>

--- a/Resources/config/filters/compass.xml
+++ b/Resources/config/filters/compass.xml
@@ -34,7 +34,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.compass" class="%assetic.filter.compass.class%">
+        <service id="assetic.filter.compass" class="%assetic.filter.compass.class%" public="true">
             <tag name="assetic.filter" alias="compass" />
             <argument>%assetic.filter.compass.bin%</argument>
             <argument>%assetic.ruby.bin%</argument>

--- a/Resources/config/filters/csscachebusting.xml
+++ b/Resources/config/filters/csscachebusting.xml
@@ -10,7 +10,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.csscachebusting" class="Assetic\Filter\CssCacheBustingFilter">
+        <service id="assetic.filter.csscachebusting" class="Assetic\Filter\CssCacheBustingFilter" public="true">
             <tag name="assetic.filter" alias="csscachebusting" />
             <call method="setVersion"><argument>%assetic.filter.csscachebusting.version%</argument></call>
             <call method="setFormat"><argument>%assetic.filter.csscachebusting.format%</argument></call>

--- a/Resources/config/filters/cssembed.xml
+++ b/Resources/config/filters/cssembed.xml
@@ -19,7 +19,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.cssembed" class="%assetic.filter.cssembed.class%">
+        <service id="assetic.filter.cssembed" class="%assetic.filter.cssembed.class%" public="true">
             <tag name="assetic.filter" alias="cssembed" />
             <argument>%assetic.filter.cssembed.jar%</argument>
             <argument>%assetic.filter.cssembed.java%</argument>

--- a/Resources/config/filters/cssimport.xml
+++ b/Resources/config/filters/cssimport.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.cssimport" class="%assetic.filter.cssimport.class%">
+        <service id="assetic.filter.cssimport" class="%assetic.filter.cssimport.class%" public="true">
             <tag name="assetic.filter" alias="cssimport" />
         </service>
     </services>

--- a/Resources/config/filters/cssmin.xml
+++ b/Resources/config/filters/cssmin.xml
@@ -11,7 +11,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.cssmin" class="%assetic.filter.cssmin.class%">
+        <service id="assetic.filter.cssmin" class="%assetic.filter.cssmin.class%" public="true">
             <tag name="assetic.filter" alias="cssmin" />
             <call method="setFilters"><argument>%assetic.filter.cssmin.filters%</argument></call>
             <call method="setPlugins"><argument>%assetic.filter.cssmin.plugins%</argument></call>

--- a/Resources/config/filters/cssrewrite.xml
+++ b/Resources/config/filters/cssrewrite.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.cssrewrite" class="%assetic.filter.cssrewrite.class%">
+        <service id="assetic.filter.cssrewrite" class="%assetic.filter.cssrewrite.class%" public="true">
             <tag name="assetic.filter" alias="cssrewrite" />
         </service>
     </services>

--- a/Resources/config/filters/dart.xml
+++ b/Resources/config/filters/dart.xml
@@ -11,7 +11,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.dart" class="%assetic.filter.dart.class%">
+        <service id="assetic.filter.dart" class="%assetic.filter.dart.class%" public="true">
             <tag name="assetic.filter" alias="dart" />
             <argument>%assetic.filter.dart.bin%</argument>
             <call method="setTimeout"><argument>%assetic.filter.dart.timeout%</argument></call>

--- a/Resources/config/filters/emberprecompile.xml
+++ b/Resources/config/filters/emberprecompile.xml
@@ -13,7 +13,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.emberprecompile" class="%assetic.filter.emberprecompile.class%">
+        <service id="assetic.filter.emberprecompile" class="%assetic.filter.emberprecompile.class%" public="true">
             <tag name="assetic.filter" alias="emberprecompile" />
             <argument>%assetic.filter.emberprecompile.bin%</argument>
             <argument>%assetic.filter.emberprecompile.node%</argument>

--- a/Resources/config/filters/gss.xml
+++ b/Resources/config/filters/gss.xml
@@ -20,7 +20,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.gss" class="%assetic.filter.gss.class%">
+        <service id="assetic.filter.gss" class="%assetic.filter.gss.class%" public="true">
             <tag name="assetic.filter" alias="gss" />
             <argument>%assetic.filter.gss.jar%</argument>
             <argument>%assetic.filter.gss.java%</argument>

--- a/Resources/config/filters/handlebars.xml
+++ b/Resources/config/filters/handlebars.xml
@@ -15,7 +15,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.handlebars" class="%assetic.filter.handlebars.class%">
+        <service id="assetic.filter.handlebars" class="%assetic.filter.handlebars.class%" public="true">
             <tag name="assetic.filter" alias="handlebars" />
             <argument>%assetic.filter.handlebars.bin%</argument>
             <argument>%assetic.filter.handlebars.node%</argument>

--- a/Resources/config/filters/jpegoptim.xml
+++ b/Resources/config/filters/jpegoptim.xml
@@ -13,7 +13,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.jpegoptim" class="%assetic.filter.jpegoptim.class%">
+        <service id="assetic.filter.jpegoptim" class="%assetic.filter.jpegoptim.class%" public="true">
             <tag name="assetic.filter" alias="jpegoptim" />
             <argument>%assetic.filter.jpegoptim.bin%</argument>
             <call method="setTimeout"><argument>%assetic.filter.jpegoptim.timeout%</argument></call>

--- a/Resources/config/filters/jpegtran.xml
+++ b/Resources/config/filters/jpegtran.xml
@@ -15,7 +15,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.jpegtran" class="%assetic.filter.jpegtran.class%">
+        <service id="assetic.filter.jpegtran" class="%assetic.filter.jpegtran.class%" public="true">
             <tag name="assetic.filter" alias="jpegtran" />
             <argument>%assetic.filter.jpegtran.bin%</argument>
             <call method="setTimeout"><argument>%assetic.filter.jpegtran.timeout%</argument></call>

--- a/Resources/config/filters/jsmin.xml
+++ b/Resources/config/filters/jsmin.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.jsmin" class="%assetic.filter.jsmin.class%">
+        <service id="assetic.filter.jsmin" class="%assetic.filter.jsmin.class%" public="true">
             <tag name="assetic.filter" alias="jsmin" />
         </service>
     </services>

--- a/Resources/config/filters/jsminplus.xml
+++ b/Resources/config/filters/jsminplus.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.jsminplus" class="%assetic.filter.jsminplus.class%">
+        <service id="assetic.filter.jsminplus" class="%assetic.filter.jsminplus.class%" public="true">
             <tag name="assetic.filter" alias="jsminplus" />
         </service>
     </services>

--- a/Resources/config/filters/jsqueeze.xml
+++ b/Resources/config/filters/jsqueeze.xml
@@ -11,7 +11,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.jsqueeze" class="Assetic\Filter\JSqueezeFilter">
+        <service id="assetic.filter.jsqueeze" class="Assetic\Filter\JSqueezeFilter" public="true">
             <tag name="assetic.filter" alias="jsqueeze" />
             <call method="setSingleLine"><argument>%assetic.filter.jsqueeze.single_line%</argument></call>
             <call method="keepImportantComments"><argument>%assetic.filter.jsqueeze.keep_important_comments%</argument></call>

--- a/Resources/config/filters/less.xml
+++ b/Resources/config/filters/less.xml
@@ -14,7 +14,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.less" class="%assetic.filter.less.class%">
+        <service id="assetic.filter.less" class="%assetic.filter.less.class%" public="true">
             <tag name="assetic.filter" alias="less" />
             <argument>%assetic.filter.less.node%</argument>
             <argument>%assetic.filter.less.node_paths%</argument>

--- a/Resources/config/filters/lessphp.xml
+++ b/Resources/config/filters/lessphp.xml
@@ -17,7 +17,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.lessphp" class="%assetic.filter.lessphp.class%">
+        <service id="assetic.filter.lessphp" class="%assetic.filter.lessphp.class%" public="true">
             <tag name="assetic.filter" alias="lessphp" />
             <call method="setPresets"><argument>%assetic.filter.lessphp.presets%</argument></call>
             <call method="setLoadPaths"><argument>%assetic.filter.lessphp.paths%</argument></call>

--- a/Resources/config/filters/minifycsscompressor.xml
+++ b/Resources/config/filters/minifycsscompressor.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="assetic.filter.minifycsscompressor" class="Assetic\Filter\MinifyCssCompressorFilter">
+        <service id="assetic.filter.minifycsscompressor" class="Assetic\Filter\MinifyCssCompressorFilter" public="true">
             <tag name="assetic.filter" alias="minifycsscompressor" />
         </service>
     </services>

--- a/Resources/config/filters/optipng.xml
+++ b/Resources/config/filters/optipng.xml
@@ -12,7 +12,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.optipng" class="%assetic.filter.optipng.class%">
+        <service id="assetic.filter.optipng" class="%assetic.filter.optipng.class%" public="true">
             <tag name="assetic.filter" alias="optipng" />
             <argument>%assetic.filter.optipng.bin%</argument>
             <call method="setTimeout"><argument>%assetic.filter.optipng.timeout%</argument></call>

--- a/Resources/config/filters/packager.xml
+++ b/Resources/config/filters/packager.xml
@@ -10,7 +10,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.packager" class="%assetic.filter.packager.class%">
+        <service id="assetic.filter.packager" class="%assetic.filter.packager.class%" public="true">
             <tag name="assetic.filter" alias="packager" />
             <argument>%assetic.filter.packager.packages%</argument>
         </service>

--- a/Resources/config/filters/packer.xml
+++ b/Resources/config/filters/packer.xml
@@ -11,7 +11,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.packer" class="Assetic\Filter\PackerFilter">
+        <service id="assetic.filter.packer" class="Assetic\Filter\PackerFilter" public="true">
             <tag name="assetic.filter" alias="packer" />
             <call method="setFastDecode"><argument>%assetic.filter.packer.fast_decode%</argument></call>
             <call method="setSpecialChars"><argument>%assetic.filter.packer.special_chars%</argument></call>

--- a/Resources/config/filters/phpcssembed.xml
+++ b/Resources/config/filters/phpcssembed.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.phpcssembed" class="%assetic.filter.phpcssembed.class%">
+        <service id="assetic.filter.phpcssembed" class="%assetic.filter.phpcssembed.class%" public="true">
             <tag name="assetic.filter" alias="phpcssembed" />
         </service>
     </services>

--- a/Resources/config/filters/pngout.xml
+++ b/Resources/config/filters/pngout.xml
@@ -15,7 +15,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.pngout" class="%assetic.filter.pngout.class%">
+        <service id="assetic.filter.pngout" class="%assetic.filter.pngout.class%" public="true">
             <tag name="assetic.filter" alias="pngout" />
             <argument>%assetic.filter.pngout.bin%</argument>
             <call method="setTimeout"><argument>%assetic.filter.pngout.timeout%</argument></call>

--- a/Resources/config/filters/reactjsx.xml
+++ b/Resources/config/filters/reactjsx.xml
@@ -10,7 +10,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.reactjsx" class="%assetic.filter.reactjsx.class%">
+        <service id="assetic.filter.reactjsx" class="%assetic.filter.reactjsx.class%" public="true">
             <tag name="assetic.filter" alias="reactjsx" />
             <argument>%assetic.filter.reactjsx.bin%</argument>
             <argument>%assetic.node.bin%</argument>

--- a/Resources/config/filters/roole.xml
+++ b/Resources/config/filters/roole.xml
@@ -12,7 +12,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.roole" class="Assetic\Filter\RooleFilter">
+        <service id="assetic.filter.roole" class="Assetic\Filter\RooleFilter" public="true">
             <tag name="assetic.filter" alias="coffee" />
             <argument>%assetic.filter.roole.bin%</argument>
             <argument>%assetic.filter.roole.node%</argument>

--- a/Resources/config/filters/sass.xml
+++ b/Resources/config/filters/sass.xml
@@ -19,7 +19,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.sass" class="%assetic.filter.sass.class%">
+        <service id="assetic.filter.sass" class="%assetic.filter.sass.class%" public="true">
             <tag name="assetic.filter" alias="sass" />
             <argument>%assetic.filter.sass.bin%</argument>
             <argument>%assetic.ruby.bin%</argument>

--- a/Resources/config/filters/scss.xml
+++ b/Resources/config/filters/scss.xml
@@ -19,7 +19,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.scss" class="%assetic.filter.scss.class%">
+        <service id="assetic.filter.scss" class="%assetic.filter.scss.class%" public="true">
             <tag name="assetic.filter" alias="scss" />
             <argument>%assetic.filter.scss.sass%</argument>
             <argument>%assetic.ruby.bin%</argument>

--- a/Resources/config/filters/scssphp.xml
+++ b/Resources/config/filters/scssphp.xml
@@ -13,7 +13,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.scssphp" class="%assetic.filter.scssphp.class%">
+        <service id="assetic.filter.scssphp" class="%assetic.filter.scssphp.class%" public="true">
             <call method="enableCompass">
                 <argument>%assetic.filter.scssphp.compass%</argument>
             </call>

--- a/Resources/config/filters/sprockets.xml
+++ b/Resources/config/filters/sprockets.xml
@@ -14,7 +14,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.sprockets" class="%assetic.filter.sprockets.class%">
+        <service id="assetic.filter.sprockets" class="%assetic.filter.sprockets.class%" public="true">
             <tag name="assetic.filter" alias="sprockets" />
             <argument>%assetic.filter.sprockets.lib%</argument>
             <argument>%assetic.filter.sprockets.ruby%</argument>

--- a/Resources/config/filters/stylus.xml
+++ b/Resources/config/filters/stylus.xml
@@ -14,7 +14,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.stylus" class="%assetic.filter.stylus.class%">
+        <service id="assetic.filter.stylus" class="%assetic.filter.stylus.class%" public="true">
             <tag name="assetic.filter" alias="stylus" />
             <argument>%assetic.filter.stylus.node%</argument>
             <argument>%assetic.filter.stylus.node_paths%</argument>

--- a/Resources/config/filters/typescript.xml
+++ b/Resources/config/filters/typescript.xml
@@ -13,7 +13,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.typescript" class="%assetic.filter.typescript.class%">
+        <service id="assetic.filter.typescript" class="%assetic.filter.typescript.class%" public="true">
             <tag name="assetic.filter" alias="typescript" />
             <argument>%assetic.filter.typescript.bin%</argument>
             <argument>%assetic.filter.typescript.node%</argument>

--- a/Resources/config/filters/uglifycss.xml
+++ b/Resources/config/filters/uglifycss.xml
@@ -16,7 +16,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.uglifycss" class="%assetic.filter.uglifycss.class%">
+        <service id="assetic.filter.uglifycss" class="%assetic.filter.uglifycss.class%" public="true">
             <tag name="assetic.filter" alias="uglifycss" />
             <argument>%assetic.filter.uglifycss.bin%</argument>
             <argument>%assetic.filter.uglifycss.node%</argument>

--- a/Resources/config/filters/uglifyjs.xml
+++ b/Resources/config/filters/uglifyjs.xml
@@ -18,7 +18,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.uglifyjs" class="%assetic.filter.uglifyjs.class%">
+        <service id="assetic.filter.uglifyjs" class="%assetic.filter.uglifyjs.class%" public="true">
             <tag name="assetic.filter" alias="uglifyjs" />
             <argument>%assetic.filter.uglifyjs.bin%</argument>
             <argument>%assetic.filter.uglifyjs.node%</argument>

--- a/Resources/config/filters/uglifyjs2.xml
+++ b/Resources/config/filters/uglifyjs2.xml
@@ -20,7 +20,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.uglifyjs2" class="%assetic.filter.uglifyjs2.class%">
+        <service id="assetic.filter.uglifyjs2" class="%assetic.filter.uglifyjs2.class%" public="true">
             <tag name="assetic.filter" alias="uglifyjs2" />
             <argument>%assetic.filter.uglifyjs2.bin%</argument>
             <argument>%assetic.filter.uglifyjs2.node%</argument>

--- a/Resources/config/filters/yui_css.xml
+++ b/Resources/config/filters/yui_css.xml
@@ -15,7 +15,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.yui_css" class="%assetic.filter.yui_css.class%">
+        <service id="assetic.filter.yui_css" class="%assetic.filter.yui_css.class%" public="true">
             <tag name="assetic.filter" alias="yui_css" />
             <argument>%assetic.filter.yui_css.jar%</argument>
             <argument>%assetic.filter.yui_css.java%</argument>

--- a/Resources/config/filters/yui_js.xml
+++ b/Resources/config/filters/yui_js.xml
@@ -18,7 +18,7 @@
     </parameters>
 
     <services>
-        <service id="assetic.filter.yui_js" class="%assetic.filter.yui_js.class%">
+        <service id="assetic.filter.yui_js" class="%assetic.filter.yui_js.class%" public="true">
             <tag name="assetic.filter" alias="yui_js" />
             <argument>%assetic.filter.yui_js.jar%</argument>
             <argument>%assetic.filter.yui_js.java%</argument>


### PR DESCRIPTION
I just set public=true to services that should be accessible.

